### PR TITLE
Naming convention for bucket files

### DIFF
--- a/consvc_shepherd/admin.py
+++ b/consvc_shepherd/admin.py
@@ -22,7 +22,7 @@ def publish_snapshot(modeladmin, request, queryset):
         snapshot.launched_by = request.user
         snapshot.launched_date = timezone.now()
         content = json.dumps(snapshot.json_settings, indent=2)
-        send_to_storage(snapshot.name, content)
+        send_to_storage(content)
         snapshot.save()
         messages.info(request, "Snapshot has been published")
 

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -108,6 +108,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
 GS_BUCKET_NAME = env("GS_BUCKET_NAME", default="")
+GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME", default="settings_from_shepherd")
 
 LOGGING = {
     "version": 1,

--- a/consvc_shepherd/storage.py
+++ b/consvc_shepherd/storage.py
@@ -6,16 +6,18 @@ from django.core.files.storage import default_storage
 
 def send_to_storage(content):
     if settings.DEBUG:
-        logging.info(f"Sending to storage, name:{settings.GS_BUCKET_FILE_NAME}, content: {content}")
+        logging.info(
+            f"Sending to storage, name:{settings.GS_BUCKET_FILE_NAME}, content: {content}"
+        )
     else:
         current_file_name = f"{settings.GS_BUCKET_FILE_NAME}-current.json"
         # write content in -current file to another file
         if default_storage.exists(current_file_name):
             creation_date = default_storage.get_created_time(current_file_name)
 
-            current_file = default_storage.open(current_file_name,"r")
+            current_file = default_storage.open(current_file_name, "r")
             current_file_contents = current_file.read()
-            previous_file_name =f"{settings.GS_BUCKET_FILE_NAME}-{creation_date}"
+            previous_file_name = f"{settings.GS_BUCKET_FILE_NAME}-{creation_date}"
 
             previous_file = default_storage.open(previous_file_name, "w")
             previous_file.write(current_file_contents)

--- a/consvc_shepherd/storage.py
+++ b/consvc_shepherd/storage.py
@@ -12,7 +12,7 @@ def send_to_storage(content):
         )
     else:
         latest_file_name = f"{settings.GS_BUCKET_FILE_NAME}_latest.json"
-        date_file_name = f"{settings.GS_BUCKET_FILE_NAME}_{timezone.now()}"
+        date_file_name = f"{settings.GS_BUCKET_FILE_NAME}_{timezone.now()}.json"
 
         date_file = default_storage.open(date_file_name, "w")
         date_file.write(content)

--- a/consvc_shepherd/storage.py
+++ b/consvc_shepherd/storage.py
@@ -4,10 +4,23 @@ from django.conf import settings
 from django.core.files.storage import default_storage
 
 
-def send_to_storage(content_name, content):
+def send_to_storage(content):
     if settings.DEBUG:
-        logging.info(f"Sending to storage name:{content_name}, content: {content}")
+        logging.info(f"Sending to storage, name:{settings.GS_BUCKET_FILE_NAME}, content: {content}")
     else:
-        file = default_storage.open(content_name, "w")
+        current_file_name = f"{settings.GS_BUCKET_FILE_NAME}-current.json"
+        # write content in -current file to another file
+        if default_storage.exists(current_file_name):
+            creation_date = default_storage.get_created_time(current_file_name)
+
+            current_file = default_storage.open(current_file_name,"r")
+            current_file_contents = current_file.read()
+            previous_file_name =f"{settings.GS_BUCKET_FILE_NAME}-{creation_date}"
+
+            previous_file = default_storage.open(previous_file_name, "w")
+            previous_file.write(current_file_contents)
+            previous_file.close()
+
+        file = default_storage.open(current_file_name, "w")
         file.write(content)
         file.close()

--- a/consvc_shepherd/storage.py
+++ b/consvc_shepherd/storage.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 from django.core.files.storage import default_storage
+from django.utils import timezone
 
 
 def send_to_storage(content):
@@ -10,19 +11,13 @@ def send_to_storage(content):
             f"Sending to storage, name:{settings.GS_BUCKET_FILE_NAME}, content: {content}"
         )
     else:
-        current_file_name = f"{settings.GS_BUCKET_FILE_NAME}-current.json"
-        # write content in -current file to another file
-        if default_storage.exists(current_file_name):
-            creation_date = default_storage.get_created_time(current_file_name)
+        latest_file_name = f"{settings.GS_BUCKET_FILE_NAME}_latest.json"
+        date_file_name = f"{settings.GS_BUCKET_FILE_NAME}_{timezone.now()}"
 
-            current_file = default_storage.open(current_file_name, "r")
-            current_file_contents = current_file.read()
-            previous_file_name = f"{settings.GS_BUCKET_FILE_NAME}-{creation_date}"
+        date_file = default_storage.open(date_file_name, "w")
+        date_file.write(content)
+        date_file.close()
 
-            previous_file = default_storage.open(previous_file_name, "w")
-            previous_file.write(current_file_contents)
-            previous_file.close()
-
-        file = default_storage.open(current_file_name, "w")
-        file.write(content)
-        file.close()
+        latest_file = default_storage.open(latest_file_name, "w")
+        latest_file.write(content)
+        latest_file.close()

--- a/consvc_shepherd/tests/test_admin.py
+++ b/consvc_shepherd/tests/test_admin.py
@@ -20,11 +20,23 @@ class SettingsSnapshotAdminTest(TestCase):
             name="Partner1", is_active=True, last_approved_by=self.request.user
         )
 
-        self.mock_storage = mock.patch(
+        self.mock_storage_open = mock.patch(
             "django.core.files.storage.default_storage." "open"
         )
-        self.mock_storage.start()
-        self.addCleanup(self.mock_storage.stop)
+        self.mock_storage_open.start()
+        self.addCleanup(self.mock_storage_open.stop)
+        self.mock_storage_exists = mock.patch(
+            "django.core.files.storage.default_storage." "exists"
+        )
+        self.mock_storage_exists.start()
+        self.addCleanup(self.mock_storage_exists.stop)
+        self.mock_storage_get_created_time = mock.patch(
+            "django.core.files.storage.default_storage." "get_created_time"
+        )
+        self.mock_storage_get_created_time.start()
+        self.addCleanup(self.mock_storage_get_created_time.stop)
+
+
 
     def test_get_read_only_fields_when_obj_exists(self):
         obj = SettingsSnapshot.objects.create(

--- a/consvc_shepherd/tests/test_admin.py
+++ b/consvc_shepherd/tests/test_admin.py
@@ -25,16 +25,6 @@ class SettingsSnapshotAdminTest(TestCase):
         )
         self.mock_storage_open.start()
         self.addCleanup(self.mock_storage_open.stop)
-        self.mock_storage_exists = mock.patch(
-            "django.core.files.storage.default_storage." "exists"
-        )
-        self.mock_storage_exists.start()
-        self.addCleanup(self.mock_storage_exists.stop)
-        self.mock_storage_get_created_time = mock.patch(
-            "django.core.files.storage.default_storage." "get_created_time"
-        )
-        self.mock_storage_get_created_time.start()
-        self.addCleanup(self.mock_storage_get_created_time.stop)
 
     def test_get_read_only_fields_when_obj_exists(self):
         obj = SettingsSnapshot.objects.create(

--- a/consvc_shepherd/tests/test_admin.py
+++ b/consvc_shepherd/tests/test_admin.py
@@ -36,8 +36,6 @@ class SettingsSnapshotAdminTest(TestCase):
         self.mock_storage_get_created_time.start()
         self.addCleanup(self.mock_storage_get_created_time.stop)
 
-
-
     def test_get_read_only_fields_when_obj_exists(self):
         obj = SettingsSnapshot.objects.create(
             name="Snapshot", settings_type=self.partner


### PR DESCRIPTION
Introduce an env for the bucket file name
The idea is that every time a new snapshot is pushed, the existing file would be rewritten under a different file name with the original creation date appended to the name.

Thoughts?