### PR TITLE
fix ad url validation

### DIFF
--- a/contile/models.py
+++ b/contile/models.py
@@ -6,8 +6,8 @@ MATCHING_CHOICES = (
     (True, "exact"),
     (False, "prefix"),
 )
-INVALID_PREFIX_PATH_ERROR = "Prefix paths can't be just '/'"
-INVALID_PATH_ERROR = "All paths need to start and end with '/'"
+INVALID_PREFIX_PATH_ERROR = "Prefix paths can't be just '/' but needs to end with '/' "
+INVALID_PATH_ERROR = "All paths need to start '/'"
 
 
 class Partner(models.Model):
@@ -81,10 +81,12 @@ class AdvertiserUrl(models.Model):
 
     def clean(self) -> None:
         is_valid_host(self.domain)
-        if not (self.path.startswith("/") and self.path.endswith("/")):
+        if not self.path.startswith("/"):
             raise ValidationError(INVALID_PATH_ERROR)
 
-        if self.get_matching_display() == "prefix" and self.path == "/":
+        if self.get_matching_display() == "prefix" and (
+            self.path == "/" or not self.path.endswith("/")
+        ):
             raise ValidationError(INVALID_PREFIX_PATH_ERROR)
 
     def save(self, *args, **kwargs):
@@ -98,7 +100,7 @@ def is_valid_host(host):
         raise ValidationError(
             f"{host}: hostnames should only contain alpha numeric characters '-' and '.'"
         )
-    if not 2 <= len(host.split(".")) <= 3 or "" in host.split("."):
+    if not 2 <= len(host.split(".")) <= 4 or "" in host.split("."):
         raise ValidationError(
-            f"{host}: hostnames should have the structure <leaf-domain>.<second-level-domain>.<top-domain> or <second-level-domain>.<top-domain>"
+            f"{host}: hostnames should have the structure <leaf-domain>.<second-level-domain>.<top-domain(s)>"
         )

--- a/contile/tests/test_models.py
+++ b/contile/tests/test_models.py
@@ -101,7 +101,7 @@ class TestAdvertiserUrlModel(TestCase):
                 advertiser=self.advertiser,
             )
         self.assertIn(
-            "hostnames should have the structure <leaf-domain>.<second-level-domain>.<top-domain> or <second-level-domain>.<top-domain>",
+            "hostnames should have the structure <leaf-domain>.<second-level-domain>.<top-domain(s)>",
             str(e.exception),
         )
 
@@ -109,13 +109,13 @@ class TestAdvertiserUrlModel(TestCase):
         with self.assertRaises(ValidationError) as e:
             AdvertiserUrl.objects.create(
                 geo="CA",
-                domain="example..com",
+                domain="www.example.co.uk.com",
                 path="/hello/",
                 matching=False,
                 advertiser=self.advertiser,
             )
         self.assertIn(
-            "hostnames should have the structure <leaf-domain>.<second-level-domain>.<top-domain> or <second-level-domain>.<top-domain>",
+            "hostnames should have the structure <leaf-domain>.<second-level-domain>.<top-domain(s)>",
             str(e.exception),
         )
 
@@ -143,7 +143,7 @@ class TestAdvertiserUrlModel(TestCase):
                 advertiser=self.advertiser,
             )
         self.assertIn(
-            "All paths need to start and end with '/'",
+            "Prefix paths can't be just '/' but needs to end with '/'",
             str(e.exception),
         )
 
@@ -189,7 +189,7 @@ class TestAdvertiserUrlModel(TestCase):
         AdvertiserUrl.objects.create(
             geo="BR",
             domain="www.example.com",
-            path="/exact/",
+            path="/exact",
             matching=True,
             advertiser=self.advertiser,
         )
@@ -197,7 +197,7 @@ class TestAdvertiserUrlModel(TestCase):
             AdvertiserUrl.objects.filter(
                 geo="BR",
                 domain="www.example.com",
-                path="/exact/",
+                path="/exact",
                 matching=True,
                 advertiser=self.advertiser,
             ).count(),


### PR DESCRIPTION
was trying to automate inputting existing data into shepherd

hit into the following cases:

- urls like www.foo.co.uk were not allowed by shepherd
- paths /hello was not allowed for exacts

These currently exist in the contile settings, so I made changes to allow them