### PR TITLE
fix: remove header prefix for openidc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ DEBUG=true
 SHEPHERD_ENV=INFO
 SECRET_KEY=keyboard-mash
 DATABASE_URL=postgres://postgres:postgres@db/consvc_shepherd
+OPENIDC_HEADER_PREFIX=
+OPENIDC_HEADER=

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -19,7 +19,8 @@ SECRET_KEY: str = env("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG", default=False)
 DEV_USER_EMAIL = "dev@example.com"
-OPENIDC_EMAIL_HEADER = env("OPENIDC_EMAIL_HEADER", default=False)
+OPENIDC_EMAIL_HEADER = env("OPENIDC_EMAIL_HEADER", default=None)
+OPENIDC_EMAIL_HEADER_PREFIX = env("OPENIDC_EMAIL_HEADER_PREFIX", default=None)
 ALLOWED_HOSTS: List[str] = ["*"]
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -19,8 +19,8 @@ SECRET_KEY: str = env("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG", default=False)
 DEV_USER_EMAIL = "dev@example.com"
-OPENIDC_EMAIL_HEADER = env("OPENIDC_EMAIL_HEADER", default=None)
-OPENIDC_EMAIL_HEADER_PREFIX = env("OPENIDC_EMAIL_HEADER_PREFIX", default=None)
+OPENIDC_HEADER = env("OPENIDC_HEADER", default=None)
+OPENIDC_HEADER_PREFIX = env("OPENIDC_HEADER_PREFIX", default=None)
 ALLOWED_HOSTS: List[str] = ["*"]
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/openidc/middleware.py
+++ b/openidc/middleware.py
@@ -19,19 +19,17 @@ class OpenIDCAuthMiddleware(AuthenticationMiddleware):
 
     def __call__(self, request):
         default_email = settings.DEV_USER_EMAIL if settings.DEBUG else None
-        openidc_email_header_value = request.META.get(
-            settings.OPENIDC_EMAIL_HEADER, default_email
-        )
+        openidc_header_value = request.META.get(settings.OPENIDC_HEADER, default_email)
 
-        if openidc_email_header_value is None:
+        if openidc_header_value is None:
             # If a user has bypassed the OpenIDC flow entirely and no header
             # is set then we reject the request entirely
             return HttpResponse("Please login using OpenID Connect", status=401)
 
         try:
-            openidc_email = openidc_email_header_value.split(
-                settings.OPENIDC_EMAIL_HEADER_PREFIX
-            )[-1]
+            openidc_email = openidc_header_value.split(settings.OPENIDC_HEADER_PREFIX)[
+                -1
+            ]
             user = self.User.objects.get(username=openidc_email)
         except self.User.DoesNotExist:
             user = self.User(username=openidc_email, email=openidc_email)

--- a/openidc/middleware.py
+++ b/openidc/middleware.py
@@ -19,14 +19,19 @@ class OpenIDCAuthMiddleware(AuthenticationMiddleware):
 
     def __call__(self, request):
         default_email = settings.DEV_USER_EMAIL if settings.DEBUG else None
-        openidc_email = request.META.get(settings.OPENIDC_EMAIL_HEADER, default_email)
+        openidc_email_header_value = request.META.get(
+            settings.OPENIDC_EMAIL_HEADER, default_email
+        )
 
-        if openidc_email is None:
+        if openidc_email_header_value is None:
             # If a user has bypassed the OpenIDC flow entirely and no header
             # is set then we reject the request entirely
             return HttpResponse("Please login using OpenID Connect", status=401)
 
         try:
+            openidc_email = openidc_email_header_value.split(
+                settings.OPENIDC_EMAIL_HEADER_PREFIX
+            )[-1]
             user = self.User.objects.get(username=openidc_email)
         except self.User.DoesNotExist:
             user = self.User(username=openidc_email, email=openidc_email)

--- a/openidc/test_middleware.py
+++ b/openidc/test_middleware.py
@@ -15,12 +15,12 @@ class OpenIDCAuthMiddlewareTests(TestCase):
         self.mock_resolve = mock_resolve_patcher.start()
         self.addCleanup(mock_resolve_patcher.stop)
 
-    @override_settings(OPENIDC_EMAIL_HEADER_PREFIX="accounts.google.com:")
+    @override_settings(OPENIDC_HEADER_PREFIX="accounts.google.com:")
     def test_user_created_with_correct_email_from_header(self):
         header_value = "accounts.google.com:user@example.com"
 
         request = mock.Mock()
-        request.META = {settings.OPENIDC_EMAIL_HEADER: header_value}
+        request.META = {settings.OPENIDC_HEADER: header_value}
 
         User = get_user_model()
         self.assertEqual(User.objects.all().count(), 0)
@@ -31,12 +31,12 @@ class OpenIDCAuthMiddlewareTests(TestCase):
         self.assertEqual(User.objects.all().count(), 1)
         self.assertEqual("user@example.com", request.user.email)
 
-    @override_settings(OPENIDC_EMAIL_HEADER_PREFIX=None)
+    @override_settings(OPENIDC_HEADER_PREFIX=None)
     def test_user_created_with_dev_email_when_no_header(self):
         header_value = "user@example.com"
 
         request = mock.Mock()
-        request.META = {settings.OPENIDC_EMAIL_HEADER: header_value}
+        request.META = {settings.OPENIDC_HEADER: header_value}
 
         User = get_user_model()
 

--- a/openidc/test_middleware.py
+++ b/openidc/test_middleware.py
@@ -1,0 +1,49 @@
+import mock
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+
+
+from openidc.middleware import OpenIDCAuthMiddleware
+
+
+class OpenIDCAuthMiddlewareTests(TestCase):
+    def setUp(self):
+        self.response = "Response"
+        self.middleware = OpenIDCAuthMiddleware(lambda request: self.response)
+
+        mock_resolve_patcher = mock.patch("django.urls.resolve")
+        self.mock_resolve = mock_resolve_patcher.start()
+        self.addCleanup(mock_resolve_patcher.stop)
+
+    @override_settings(OPENIDC_EMAIL_HEADER_PREFIX="accounts.google.com:")
+    def test_user_created_with_correct_email_from_header(self):
+        header_value = "accounts.google.com:user@example.com"
+
+        request = mock.Mock()
+        request.META = {settings.OPENIDC_EMAIL_HEADER: header_value}
+
+        User = get_user_model()
+        self.assertEqual(User.objects.all().count(), 0)
+
+        response = self.middleware(request)
+
+        self.assertEqual(response, self.response)
+        self.assertEqual(User.objects.all().count(), 1)
+        self.assertEqual("user@example.com", request.user.email)
+
+    @override_settings(OPENIDC_EMAIL_HEADER_PREFIX=None)
+    def test_user_created_with_dev_email_when_no_header(self):
+        header_value = "user@example.com"
+
+        request = mock.Mock()
+        request.META = {settings.OPENIDC_EMAIL_HEADER: header_value}
+
+        User = get_user_model()
+
+        self.assertEqual(User.objects.all().count(), 0)
+        response = self.middleware(request)
+
+        self.assertEqual(response, self.response)
+        self.assertEqual(User.objects.all().count(), 1)
+        self.assertEqual("user@example.com", request.user.email)

--- a/openidc/test_middleware.py
+++ b/openidc/test_middleware.py
@@ -3,7 +3,6 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 
-
 from openidc.middleware import OpenIDCAuthMiddleware
 
 


### PR DESCRIPTION
`X-Goog-Authenticated-User-Email` returns value of format `accounts.google.com:example@gmail.com`
So we need to remove that before going ahead and creating a user
ref: https://cloud.google.com/iap/docs/identity-howto#getting_the_users_identity_with_signed_headers

closes #CONSVC-2120