### PR TITLE
fix: auth gcp jwt header[MERGE ON HOLD]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ SECRET_KEY=keyboard-mash
 DATABASE_URL=postgres://postgres:postgres@db/consvc_shepherd
 OPENIDC_HEADER_PREFIX=
 OPENIDC_HEADER=
+IAP_AUDIENCE=

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -21,6 +21,7 @@ DEBUG = env("DEBUG", default=False)
 DEV_USER_EMAIL = "dev@example.com"
 OPENIDC_HEADER = env("OPENIDC_HEADER", default=None)
 OPENIDC_HEADER_PREFIX = env("OPENIDC_HEADER_PREFIX", default=None)
+IAP_AUDIENCE = env("IAP_AUDIENCE", default=None)
 ALLOWED_HOSTS: List[str] = ["*"]
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -130,6 +130,10 @@ LOGGING = {
         },
     },
     "loggers": {
+        "shepherd": {
+            "handlers": ["console"],
+            "level": env("SHEPHERD_ENV", default="DEBUG"),
+        },
         "request.summary": {
             "handlers": ["console"],
             "level": env("SHEPHERD_ENV", default="DEBUG"),

--- a/openidc/middleware.py
+++ b/openidc/middleware.py
@@ -7,6 +7,8 @@ from django.http import HttpResponse
 from google.auth.transport import requests
 from google.oauth2 import id_token
 
+logger = logging.getLogger("shepherd")
+
 
 def validate_iap_jwt(request):
     iap_jwt = request.META.get(settings.OPENIDC_HEADER)
@@ -18,8 +20,8 @@ def validate_iap_jwt(request):
             certs_url="https://www.gstatic.com/iap/verify/public_key",
         )
         return decoded_jwt["email"]
-    except ValueError as e:
-        logging.error(f"**ERROR: JWT validation error {e}**'.")
+    except Exception as e:
+        logger.error(f"**ERROR: JWT validation error {e}**'.")
 
 
 def validate_openidc_header(request):

--- a/openidc/middleware.py
+++ b/openidc/middleware.py
@@ -21,7 +21,7 @@ def validate_iap_jwt(request):
         )
         return decoded_jwt["email"]
     except Exception as e:
-        logger.error(f"**ERROR: JWT validation error {e}**'.")
+        logger.error(f"IAP JWT validation error: {e}")
 
 
 def validate_openidc_header(request):

--- a/openidc/test_middleware.py
+++ b/openidc/test_middleware.py
@@ -15,7 +15,13 @@ class OpenIDCAuthMiddlewareTests(TestCase):
         self.mock_resolve = mock_resolve_patcher.start()
         self.addCleanup(mock_resolve_patcher.stop)
 
-    @override_settings(OPENIDC_HEADER_PREFIX="accounts.google.com:")
+        mock_verify_token_patcher = mock.patch("google.oauth2.id_token.verify_token")
+
+        self.mock_verify_token = mock_verify_token_patcher.start()
+        self.mock_verify_token.return_value = {"email": "non-dev@example.com"}
+        self.addCleanup(mock_verify_token_patcher.stop)
+
+    @override_settings(OPENIDC_HEADER_PREFIX="accounts.google.com:", DEBUG=True)
     def test_user_created_with_correct_email_from_header(self):
         header_value = "accounts.google.com:user@example.com"
 
@@ -31,9 +37,23 @@ class OpenIDCAuthMiddlewareTests(TestCase):
         self.assertEqual(User.objects.all().count(), 1)
         self.assertEqual("user@example.com", request.user.email)
 
-    @override_settings(OPENIDC_HEADER_PREFIX=None)
+    @override_settings(DEBUG=True)
     def test_user_created_with_dev_email_when_no_header(self):
-        header_value = "user@example.com"
+
+        request = mock.Mock()
+        request.META = {}
+        User = get_user_model()
+
+        self.assertEqual(User.objects.all().count(), 0)
+        response = self.middleware(request)
+
+        self.assertEqual(response, self.response)
+        self.assertEqual(User.objects.all().count(), 1)
+        self.assertEqual("dev@example.com", request.user.email)
+
+    @override_settings(DEBUG=False)
+    def test_user_created_with_jwt_header(self):
+        header_value = "x-goog-iap-jwt-assertion"
 
         request = mock.Mock()
         request.META = {settings.OPENIDC_HEADER: header_value}
@@ -45,4 +65,4 @@ class OpenIDCAuthMiddlewareTests(TestCase):
 
         self.assertEqual(response, self.response)
         self.assertEqual(User.objects.all().count(), 1)
-        self.assertEqual("user@example.com", request.user.email)
+        self.assertEqual("non-dev@example.com", request.user.email)

--- a/requirements.in
+++ b/requirements.in
@@ -13,6 +13,7 @@ django-stubs
 dockerflow
 factory_boy
 flake8
+google
 isort
 mypy
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,81 +4,87 @@
 #
 #    pip-compile
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via django
-attrs==21.4.0
+attrs==22.1.0
     # via pytest
-black==22.3.0
+beautifulsoup4==4.11.1
+    # via google
+black==22.10.0
     # via -r requirements.in
-cachetools==5.0.0
+cachetools==5.2.0
     # via google-auth
-certifi==2021.10.8
+certifi==2022.9.24
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via requests
-click==8.1.2
+click==8.1.3
     # via black
-coverage[toml]==6.3.2
+coverage[toml]==6.5.0
     # via
     #   -r requirements.in
     #   pytest-cov
-django==4.0.8
+django==4.1.3
     # via
     #   -r requirements.in
     #   django-polymorphic
     #   django-storages
     #   django-stubs
     #   django-stubs-ext
-django-countries==7.3.2
+django-countries==7.4.2
     # via -r requirements.in
-django-environ==0.8.1
+django-environ==0.9.0
     # via -r requirements.in
 django-polymorphic==3.1.0
     # via -r requirements.in
-django-storages[google]==1.12.3
+django-storages[google]==1.13.1
     # via -r requirements.in
-django-stubs==1.10.1
+django-stubs==1.13.0
     # via -r requirements.in
-django-stubs-ext==0.4.0
+django-stubs-ext==0.7.0
     # via django-stubs
-dockerflow==2022.7.0
+dockerflow==2022.8.0
     # via -r requirements.in
+exceptiongroup==1.0.4
+    # via pytest
 factory-boy==3.2.1
     # via -r requirements.in
-faker==13.4.0
+faker==15.3.3
     # via factory-boy
-flake8==4.0.1
+flake8==6.0.0
     # via -r requirements.in
-google-api-core==2.7.2
+google==3.0.0
+    # via -r requirements.in
+google-api-core==2.10.2
     # via
     #   google-cloud-core
     #   google-cloud-storage
-google-auth==2.6.6
+google-auth==2.14.1
     # via
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-storage
-google-cloud-core==2.3.0
+google-cloud-core==2.3.2
     # via google-cloud-storage
-google-cloud-storage==2.3.0
+google-cloud-storage==2.6.0
     # via django-storages
-google-crc32c==1.3.0
+google-crc32c==1.5.0
     # via google-resumable-media
-google-resumable-media==2.3.2
+google-resumable-media==2.4.0
     # via google-cloud-storage
-googleapis-common-protos==1.56.0
+googleapis-common-protos==1.57.0
     # via google-api-core
-idna==3.3
+idna==3.4
     # via requests
 iniconfig==1.1.1
     # via pytest
 isort==5.10.1
     # via -r requirements.in
-mccabe==0.6.1
+mccabe==0.7.0
     # via flake8
 mock==4.0.3
     # via -r requirements.in
-mypy==0.942
+mypy==0.991
     # via
     #   -r requirements.in
     #   django-stubs
@@ -88,55 +94,54 @@ mypy-extensions==0.4.3
     #   mypy
 packaging==21.3
     # via pytest
-pathspec==0.9.0
+pathspec==0.10.2
     # via black
-platformdirs==2.5.2
+platformdirs==2.5.4
     # via black
 pluggy==1.0.0
     # via pytest
-protobuf==3.20.2
+protobuf==4.21.9
     # via
     #   google-api-core
-    #   google-cloud-storage
     #   googleapis-common-protos
-psycopg2-binary==2.9.4
+psycopg2-binary==2.9.5
     # via -r requirements.in
-py==1.11.0
-    # via pytest
 pyasn1==0.4.8
     # via
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pycodestyle==2.8.0
+pycodestyle==2.10.0
     # via flake8
-pyflakes==2.4.0
+pyflakes==3.0.0
     # via flake8
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via packaging
-pytest==7.1.2
+pytest==7.2.0
     # via
     #   -r requirements.in
     #   pytest-cov
     #   pytest-django
-pytest-cov==3.0.0
+pytest-cov==4.0.0
     # via -r requirements.in
 pytest-django==4.5.2
     # via -r requirements.in
 python-dateutil==2.8.2
     # via faker
-requests==2.27.1
+requests==2.28.1
     # via
     #   google-api-core
     #   google-cloud-storage
-rsa==4.8
+rsa==4.9
     # via google-auth
 six==1.16.0
     # via
     #   google-auth
     #   python-dateutil
-sqlparse==0.4.2
+soupsieve==2.3.2.post1
+    # via beautifulsoup4
+sqlparse==0.4.3
     # via django
 tomli==2.0.1
     # via
@@ -145,15 +150,15 @@ tomli==2.0.1
     #   django-stubs
     #   mypy
     #   pytest
-types-pytz==2021.3.6
+types-pytz==2022.6.0.1
     # via django-stubs
-types-pyyaml==6.0.7
+types-pyyaml==6.0.12.2
     # via django-stubs
-typing-extensions==4.2.0
+typing-extensions==4.4.0
     # via
     #   django-countries
     #   django-stubs
     #   django-stubs-ext
     #   mypy
-urllib3==1.26.9
+urllib3==1.26.13
     # via requests


### PR DESCRIPTION
Using JWT is preferred over using simply the google email header.

I've made changes so that the email header should work when `debug=True`. It should also work if the email header isn't there.

JWT validation only occurs when `debug=False`