### PR TITLE
feat: add Shepherd Overview Page

### DIFF
--- a/consvc_shepherd/forms.py
+++ b/consvc_shepherd/forms.py
@@ -1,0 +1,43 @@
+from django import forms
+
+from consvc_shepherd.models import SettingsSnapshot
+
+
+class SnapshotCompareForm(forms.Form):
+    older_snapshot = forms.CharField(
+        label="Older Snapshot",
+        widget=forms.Select(
+            choices=(
+                (snapshot.name, snapshot)
+                for snapshot in SettingsSnapshot.objects.all().order_by("-created_on")
+            )
+        ),
+    )
+    newer_snapshot = forms.CharField(
+        label="Newer Snapshot",
+        widget=forms.Select(
+            choices=(
+                (snapshot.name, snapshot)
+                for snapshot in SettingsSnapshot.objects.all().order_by("-created_on")
+            )
+        ),
+    )
+
+    def compare(self):
+        os_name = self.data["older_snapshot"]
+        ns_name = self.data["newer_snapshot"]
+        older_json_settings = SettingsSnapshot.objects.get(name=os_name).json_settings
+        newer_json_settings = SettingsSnapshot.objects.get(name=ns_name).json_settings
+
+        older_advertisers = set(older_json_settings["adm_advertisers"].keys())
+        newer_advertisers = set(newer_json_settings["adm_advertisers"].keys())
+
+        added_advertisers = sorted(list(newer_advertisers - older_advertisers))
+        removed_advertisers = sorted(list(older_advertisers - newer_advertisers))
+        return {
+            "title": f"Comparing {os_name} with {ns_name}",
+            "differences": [
+                {"diff_type": "Added Advertisers", "diff_value": added_advertisers},
+                {"diff_type": "Removed Advertisers", "diff_value": removed_advertisers},
+            ],
+        }

--- a/consvc_shepherd/forms.py
+++ b/consvc_shepherd/forms.py
@@ -32,8 +32,8 @@ class SnapshotCompareForm(forms.Form):
         older_advertisers = set(older_json_settings["adm_advertisers"].keys())
         newer_advertisers = set(newer_json_settings["adm_advertisers"].keys())
 
-        added_advertisers = sorted(list(newer_advertisers - older_advertisers))
-        removed_advertisers = sorted(list(older_advertisers - newer_advertisers))
+        added_advertisers = sorted(newer_advertisers - older_advertisers)
+        removed_advertisers = sorted(older_advertisers - newer_advertisers)
         return {
             "title": f"Comparing {os_name} with {ns_name}",
             "differences": [

--- a/consvc_shepherd/models.py
+++ b/consvc_shepherd/models.py
@@ -22,7 +22,7 @@ class SettingsSnapshot(models.Model):
     launched_date = models.DateTimeField(blank=True, null=True)
 
     def __str__(self):
-        return f"{self.name}: {self.created_on}"
+        return f"{self.name}: {self.created_on.strftime('%Y-%m-%d %H:%M')}"
 
     def save(self, *args, **kwargs):
         return super(SettingsSnapshot, self).save(*args, **kwargs)

--- a/consvc_shepherd/tests/test_forms.py
+++ b/consvc_shepherd/tests/test_forms.py
@@ -1,0 +1,38 @@
+from django.test import TestCase
+
+from consvc_shepherd.forms import SnapshotCompareForm
+from consvc_shepherd.models import SettingsSnapshot
+
+
+class TestSnapshotCompareForm(TestCase):
+    def test_required_fields_for_form(self):
+        data = {
+            "newer_snapshot": "Snapshot 1",
+        }
+        form = SnapshotCompareForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors, {"older_snapshot": ["This field is required."]})
+
+    def test_compare_returns_differences(self):
+        SettingsSnapshot.objects.create(
+            name="o_snapshot", json_settings={"adm_advertisers": {"advertiser1": {}}}
+        )
+        SettingsSnapshot.objects.create(
+            name="n_snapshot",
+            json_settings={"adm_advertisers": {"advertiser2": {}, "advertiser3": {}}},
+        )
+        data = {"older_snapshot": "o_snapshot", "newer_snapshot": "n_snapshot"}
+        form = SnapshotCompareForm(data=data)
+        self.assertTrue(form.is_valid())
+        differences = form.compare()
+        expected_differences = {
+            "differences": [
+                {
+                    "diff_type": "Added Advertisers",
+                    "diff_value": ["advertiser2", "advertiser3"],
+                },
+                {"diff_type": "Removed Advertisers", "diff_value": ["advertiser1"]},
+            ],
+            "title": "Comparing o_snapshot with n_snapshot",
+        }
+        self.assertEqual(differences, expected_differences)

--- a/consvc_shepherd/tests/test_views.py
+++ b/consvc_shepherd/tests/test_views.py
@@ -1,0 +1,25 @@
+from django.test import TestCase, override_settings
+
+from consvc_shepherd.models import SettingsSnapshot
+
+
+# override DEBUG to override auth check
+@override_settings(DEBUG=True)
+class TestExperimentRisksUpdateView(TestCase):
+    def test_view_returns_post_request(self):
+        SettingsSnapshot.objects.create(
+            name="o_snapshot", json_settings={"adm_advertisers": {"advertiser1": {}}}
+        )
+        SettingsSnapshot.objects.create(
+            name="n_snapshot",
+            json_settings={"adm_advertisers": {"advertiser2": {}, "advertiser3": {}}},
+        )
+
+        data = {"older_snapshot": "o_snapshot", "newer_snapshot": "n_snapshot"}
+
+        response = self.client.post(
+            "",
+            data,
+            **{"settings.OPENIDC_HEADER": "dev@example.com"},
+        )
+        self.assertEqual(response.status_code, 200)

--- a/consvc_shepherd/urls.py
+++ b/consvc_shepherd/urls.py
@@ -16,6 +16,9 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
+from consvc_shepherd.views import TableOverview
+
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("", TableOverview.as_view()),
 ]

--- a/consvc_shepherd/views.py
+++ b/consvc_shepherd/views.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+from django.shortcuts import render
+from django.views.generic import TemplateView
+
+from consvc_shepherd.forms import SnapshotCompareForm
+from consvc_shepherd.models import SettingsSnapshot
+
+
+class TableOverview(TemplateView):
+    template_name = "index.html"
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context["data"] = SettingsSnapshot.objects.all().order_by("-created_on")
+        context["form"] = SnapshotCompareForm
+        return context
+
+    def post(self, request, *args, **kwargs):
+        context = self.get_context_data()
+        form = SnapshotCompareForm(request.POST)
+        if form.is_valid():
+            context["comparison_values"] = form.compare()
+            return render(request, self.template_name, context=context)
+        else:
+            context["errors"] = form.errors
+            return render(request, self.template_name, context=context)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
+    <title>Shepherd</title>
+</head>
+<body>
+    <div class="p-5">
+        <h1>Shepherd</h1>
+        <div class="m-4">
+            <h2>Compare Snapshots</h2>
+            {% if comparison_values %}
+                <div class="alert alert-primary" role="alert">
+                    <h3>{{ comparison_values.title }}</h3>
+                    {% for diff in comparison_values.differences %}
+                        <p>{{ diff.diff_type }}</p>
+                        <p class="m-2">{{ diff.diff_value }}</p>
+                    {% endfor %}
+                </div>
+            {% endif %}
+            {% if errors %}
+                <div class="alert alert-danger" role="alert">
+                    {{ errors }}
+                </div>
+            {% endif %}
+
+            <div class="d-flex w-100 align-items-center">
+                <form action="" method="post">
+                    {% csrf_token %}
+                    {{ form }}
+                    <button class="btn btn-primary ml-2">Submit</button>
+                </form>
+            </div>
+
+        </div>
+        <div class="m-4">
+            <h2 class="my-2">Shepherd's Latest Snapshot ({{ data.first.name }})</h2>
+            {% with something=data.first.json_settings %}
+                {% for element, geo_values in something.adm_advertisers.items %}
+                    <div class="m-4">
+                        <h3>{{ element }}</h3>
+                        <table class="table table-striped">
+                            <tr>
+                                <th>Geo</th>
+                                <th>Domains</th>
+                                <th>Paths</th>
+                            </tr>
+                            {% for geo, domains in geo_values.items %}
+                                {% for domain in domains %}
+                                    <tr>
+                                        <td rowspan="{{ domains | length }}" class="col-md-3">{{ geo }}</td>
+                                        <td class="col-md-3">{{ domain.host }}</td>
+                                        <td>{% for path in domain.paths %} {{ path.value }},{% endfor %}</td>
+                                    </tr>
+                                {% endfor %}
+                            {% endfor %}
+                        </table>
+                    </div>
+                {% endfor %}
+            {% endwith %}
+        </div>
+    </div>
+  </body>
+</html>
+
+
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,6 @@
                     {{ errors }}
                 </div>
             {% endif %}
-
             <div class="d-flex w-100 align-items-center">
                 <form action="" method="post">
                     {% csrf_token %}
@@ -33,7 +32,6 @@
                     <button class="btn btn-primary ml-2">Submit</button>
                 </form>
             </div>
-
         </div>
         <div class="m-4">
             <h2 class="my-2">Shepherd's Latest Snapshot ({{ data.first.name }})</h2>
@@ -64,6 +62,3 @@
     </div>
   </body>
 </html>
-
-
-


### PR DESCRIPTION

![Screen Shot 2023-01-30 at 8 57 26 PM](https://user-images.githubusercontent.com/25379936/215921937-ce95cfe2-da80-473e-9b8e-eb501dc4dc41.png)


The overview page includes:

- a table view of the latest Snapshot.
- two select input so that a user can get the difference between to snapshots

The difference logic only accounts for the addition and or removal of advertisers,
I will put the advertiser hosts/paths logic as a follow up, as this is quite a bit already.