### PR TITLE
[DISCO-2304] fix: UI snapshot dropdowns update with new snapshots

### DIFF
--- a/consvc_shepherd/forms.py
+++ b/consvc_shepherd/forms.py
@@ -4,30 +4,20 @@ from consvc_shepherd.models import SettingsSnapshot
 
 
 class SnapshotCompareForm(forms.Form):
-    older_snapshot = forms.CharField(
+    older_snapshot = forms.ModelChoiceField(
         label="Older Snapshot",
-        widget=forms.Select(
-            choices=(
-                (snapshot.name, snapshot)
-                for snapshot in SettingsSnapshot.objects.all().order_by("-created_on")
-            )
-        ),
+        queryset=SettingsSnapshot.objects.all().order_by("-created_on"),
     )
-    newer_snapshot = forms.CharField(
+    newer_snapshot = forms.ModelChoiceField(
         label="Newer Snapshot",
-        widget=forms.Select(
-            choices=(
-                (snapshot.name, snapshot)
-                for snapshot in SettingsSnapshot.objects.all().order_by("-created_on")
-            )
-        ),
+        queryset=SettingsSnapshot.objects.all().order_by("-created_on"),
     )
 
     def compare(self):
-        os_name = self.data["older_snapshot"]
-        ns_name = self.data["newer_snapshot"]
-        older_json_settings = SettingsSnapshot.objects.get(name=os_name).json_settings
-        newer_json_settings = SettingsSnapshot.objects.get(name=ns_name).json_settings
+        os = SettingsSnapshot.objects.get(id=self.data["older_snapshot"])
+        ns = SettingsSnapshot.objects.get(id=self.data["newer_snapshot"])
+        older_json_settings = os.json_settings
+        newer_json_settings = ns.json_settings
 
         older_advertisers = set(older_json_settings["adm_advertisers"].keys())
         newer_advertisers = set(newer_json_settings["adm_advertisers"].keys())
@@ -35,7 +25,7 @@ class SnapshotCompareForm(forms.Form):
         added_advertisers = sorted(newer_advertisers - older_advertisers)
         removed_advertisers = sorted(older_advertisers - newer_advertisers)
         return {
-            "title": f"Comparing {os_name} with {ns_name}",
+            "title": f"Comparing {os.name} with {ns.name}",
             "differences": [
                 {"diff_type": "Added Advertisers", "diff_value": added_advertisers},
                 {"diff_type": "Removed Advertisers", "diff_value": removed_advertisers},


### PR DESCRIPTION
Currently the compare snapshot ui dropdowns don't update when new setting snapshots are created, seems like setting choices like below doesn't dynamically get new snapshots
``` 
choices=(
                (snapshot.name, snapshot)
                for snapshot in SettingsSnapshot.objects.all().order_by("-created_on")
            ) 
```