### PR TITLE
fix: Advertiser Name json schema field to allow all characters

### DIFF
--- a/schema/shepherd.schema.json
+++ b/schema/shepherd.schema.json
@@ -10,7 +10,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^[a-zA-Z\\d]*$": {
+        "^[a-zA-Z0-9 '!@#$&()\\\\-`.+,/\\\"]*$": {
           "description": "Specific Advertiser Data",
           "type": "object",
           "additionalProperties": false,

--- a/schema/test_schema.py
+++ b/schema/test_schema.py
@@ -16,7 +16,8 @@ class JSONSchema(TestCase):
                 name="Partner Advertiser",
             )
             advertiser1 = Advertiser.objects.create(name="Pocket", partner=partner)
-            advertiser2 = Advertiser.objects.create(name="Firefox", partner=partner)
+            # we want to test that Advertiser names with special characters are valid
+            advertiser2 = Advertiser.objects.create(name="F!re fox+", partner=partner)
             AdvertiserUrl.objects.create(
                 advertiser=advertiser1,
                 path="/hello/",


### PR DESCRIPTION
🙈 ... didn't account for Advertiser names with spaces and special characters
not sure if there is a more efficient way to specify all characters?