### PR TITLE
[DISCO-2361] New Allocation File Capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 # VS Code configuration files
 .vscode/*
 !.vscode/launch.json
+
+# DB Synchronization Stamps
+.install.stamp

--- a/consvc_shepherd/admin.py
+++ b/consvc_shepherd/admin.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.contrib import admin, messages
 from django.utils import timezone
 from jsonschema import exceptions, validate
@@ -26,7 +27,7 @@ def publish_snapshot(modeladmin, request, queryset):
             settings_schema = json.load(f)
             try:
                 validate(snapshot.json_settings, schema=settings_schema)
-                send_to_storage(content)
+                send_to_storage(content, settings.GS_BUCKET_FILE_NAME)
                 snapshot.save()
                 messages.info(request, "Snapshot has been published")
             except exceptions.ValidationError:

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -32,9 +32,6 @@ SESSION_COOKIE_SECURE = env("SESSION_COOKIE_SECURE", default=True, cast=bool)
 CSRF_COOKIE_SECURE = env("CSRF_COOKIE_SECURE", default=True, cast=bool)
 SECURE_REFERRER_POLICY = env("SECURE_REFERRER_POLICY", default="origin")
 
-# Contile Output File Name
-CONTILE_OUTPUT_FILE_NAME: str = "CONTILE_OUTPUT_FILE_NAME"
-
 # Application definition
 
 INSTALLED_APPS: list[str] = [
@@ -122,6 +119,7 @@ DEFAULT_AUTO_FIELD: str = "django.db.models.BigAutoField"
 DEFAULT_FILE_STORAGE: str = "storages.backends.gcloud.GoogleCloudStorage"
 GS_BUCKET_NAME = env("GS_BUCKET_NAME", default="")
 GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME", default="settings_from_shepherd")
+ALLOCATION_FILE_NAME: str = env("ALLOCATION_FILE_NAME", default="allocation_file")
 
 LOGGING: dict[str, Any] = {
     "version": 1,

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -33,7 +33,7 @@ CSRF_COOKIE_SECURE = env("CSRF_COOKIE_SECURE", default=True, cast=bool)
 SECURE_REFERRER_POLICY = env("SECURE_REFERRER_POLICY", default="origin")
 
 # Contile Output File Name
-CONTILE_OUTPUT_FILE_NAME = env("CONTILE_OUTPUT_FILE_NAME", default="contile_output.json")
+CONTILE_OUTPUT_FILE_NAME = env("CONTILE_OUTPUT_FILE_NAME")
 
 # Application definition
 

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from typing import List
+from typing import Any
 
 import environ
 import sentry_sdk
@@ -25,7 +25,7 @@ DEV_USER_EMAIL = "dev@example.com"
 OPENIDC_HEADER = env("OPENIDC_HEADER", default=None)
 OPENIDC_HEADER_PREFIX = env("OPENIDC_HEADER_PREFIX", default=None)
 IAP_AUDIENCE = env("IAP_AUDIENCE", default=None)
-ALLOWED_HOSTS: List[str] = ["*"]
+ALLOWED_HOSTS: list[str] = ["*"]
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SESSION_COOKIE_SECURE = env("SESSION_COOKIE_SECURE", default=True, cast=bool)
@@ -33,11 +33,11 @@ CSRF_COOKIE_SECURE = env("CSRF_COOKIE_SECURE", default=True, cast=bool)
 SECURE_REFERRER_POLICY = env("SECURE_REFERRER_POLICY", default="origin")
 
 # Contile Output File Name
-CONTILE_OUTPUT_FILE_NAME = env("CONTILE_OUTPUT_FILE_NAME")
+CONTILE_OUTPUT_FILE_NAME: str = "CONTILE_OUTPUT_FILE_NAME"
 
 # Application definition
 
-INSTALLED_APPS = [
+INSTALLED_APPS: list[str] = [
     "polymorphic",
     "consvc_shepherd",
     "contile",
@@ -51,7 +51,7 @@ INSTALLED_APPS = [
     "dockerflow.django",
 ]
 
-MIDDLEWARE = [
+MIDDLEWARE: list = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -62,9 +62,9 @@ MIDDLEWARE = [
     "openidc.middleware.OpenIDCAuthMiddleware",
 ]
 
-ROOT_URLCONF = "consvc_shepherd.urls"
+ROOT_URLCONF: str = "consvc_shepherd.urls"
 
-TEMPLATES = [
+TEMPLATES: list[dict[str, Any]] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": ["./templates"],
@@ -80,12 +80,12 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = "consvc_shepherd.wsgi.application"
+WSGI_APPLICATION: str = "consvc_shepherd.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/4.0/ref/settings/#databases
 
-DATABASES = {
+DATABASES: dict[str, Any] = {
     "default": {
         "ENGINE": "django.db.backends.postgresql_psycopg2",
         "NAME": env("DB_NAME"),
@@ -99,31 +99,31 @@ DATABASES = {
 # Internationalization
 # https://docs.djangoproject.com/en/4.0/topics/i18n/
 
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE: str = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE: str = "UTC"
 
-USE_I18N = True
+USE_I18N: bool = True
 
-USE_TZ = True
+USE_TZ: bool = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_BUCKET_NAME = env("STATIC_BUCKET_NAME", default="")
-STATIC_URL = "static/"
-STATIC_ROOT = "./static"
+STATIC_URL: str = "static/"
+STATIC_ROOT: str = "./static"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field
 
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+DEFAULT_AUTO_FIELD: str = "django.db.models.BigAutoField"
 
-DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
+DEFAULT_FILE_STORAGE: str = "storages.backends.gcloud.GoogleCloudStorage"
 GS_BUCKET_NAME = env("GS_BUCKET_NAME", default="")
 GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME", default="settings_from_shepherd")
 
-LOGGING = {
+LOGGING: dict[str, Any] = {
     "version": 1,
     "formatters": {
         "json": {"()": "dockerflow.logging.JsonLogFormatter", "logger_name": "shepherd"}
@@ -152,6 +152,7 @@ LOGGING = {
 SENTRY_DSN = env("SENTRY_DSN", default=None)
 SENTRY_TRACE_SAMPLE_RATE = env("SENTRY_TRACE_SAMPLE_RATE", default=1.0)
 SENTRY_ENV = env("SENTRY_ENV", default=None)
+
 sentry_sdk.init(
     dsn=SENTRY_DSN,
     integrations=[DjangoIntegration()],

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -32,6 +32,9 @@ SESSION_COOKIE_SECURE = env("SESSION_COOKIE_SECURE", default=True, cast=bool)
 CSRF_COOKIE_SECURE = env("CSRF_COOKIE_SECURE", default=True, cast=bool)
 SECURE_REFERRER_POLICY = env("SECURE_REFERRER_POLICY", default="origin")
 
+# Contile Output File Name
+CONTILE_OUTPUT_FILE_NAME = env("CONTILE_OUTPUT_FILE_NAME", default="contile_output.json")
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -144,6 +147,7 @@ LOGGING = {
         },
     },
 }
+
 # Sentry Setup
 SENTRY_DSN = env("SENTRY_DSN", default=None)
 SENTRY_TRACE_SAMPLE_RATE = env("SENTRY_TRACE_SAMPLE_RATE", default=1.0)

--- a/consvc_shepherd/storage.py
+++ b/consvc_shepherd/storage.py
@@ -5,10 +5,8 @@ from django.core.files.storage import default_storage
 from django.utils import timezone
 
 
-def send_to_storage(content, alt_file_name: str = "") -> None:
-    """Send adM filter settings to GCS bucket."""
-    file_name: str = alt_file_name if alt_file_name else settings.GS_BUCKET_FILE_NAME
-
+def send_to_storage(content, file_name: str) -> None:
+    """Send adM filter and allocation settings to GCS bucket."""
     if settings.DEBUG:
         logging.info(f"Sending to storage, name:{file_name}, content: {content}")
     else:

--- a/consvc_shepherd/storage.py
+++ b/consvc_shepherd/storage.py
@@ -6,14 +6,15 @@ from django.utils import timezone
 
 
 def send_to_storage(content, alt_file_name: str = "") -> None:
-    file_name = alt_file_name if alt_file_name else settings.GS_BUCKET_FILE_NAME
+    """Send adM filter settings to GCS bucket."""
+    file_name: str = alt_file_name if alt_file_name else settings.GS_BUCKET_FILE_NAME
 
     if settings.DEBUG:
         logging.info(f"Sending to storage, name:{file_name}, content: {content}")
     else:
-        current_time_string = timezone.now().strftime("%Y%m%d%H%M%S")
-        latest_file_name = f"{file_name}_latest.json"
-        date_file_name = f"{file_name}_{current_time_string}.json"
+        current_time_string: str = timezone.now().strftime("%Y%m%d%H%M%S")
+        latest_file_name: str = f"{file_name}_latest.json"
+        date_file_name: str = f"{file_name}_{current_time_string}.json"
 
         date_file = default_storage.open(date_file_name, "w")
         date_file.write(content)

--- a/consvc_shepherd/storage.py
+++ b/consvc_shepherd/storage.py
@@ -5,16 +5,14 @@ from django.core.files.storage import default_storage
 from django.utils import timezone
 
 
-def send_to_storage(content, alt_file_name:str ="") -> None:
-    file_name: str = alt_file_name if alt_file_name else settings.GS_BUCKET_FILE_NAME
+def send_to_storage(content, alt_file_name: str = "") -> None:
+    file_name = alt_file_name if alt_file_name else settings.GS_BUCKET_FILE_NAME
 
     if settings.DEBUG:
-        logging.info(
-            f"Sending to storage, name:{file_name}, content: {content}"
-        )
+        logging.info(f"Sending to storage, name:{file_name}, content: {content}")
     else:
         current_time_string = timezone.now().strftime("%Y%m%d%H%M%S")
-        latest_file_name =    f"{file_name}_latest.json"  
+        latest_file_name = f"{file_name}_latest.json"
         date_file_name = f"{file_name}_{current_time_string}.json"
 
         date_file = default_storage.open(date_file_name, "w")

--- a/consvc_shepherd/storage.py
+++ b/consvc_shepherd/storage.py
@@ -5,7 +5,7 @@ from django.core.files.storage import default_storage
 from django.utils import timezone
 
 
-def send_to_storage(content):
+def send_to_storage(content, modified_file_name="") -> None:
     if settings.DEBUG:
         logging.info(
             f"Sending to storage, name:{settings.GS_BUCKET_FILE_NAME}, content: {content}"

--- a/consvc_shepherd/storage.py
+++ b/consvc_shepherd/storage.py
@@ -5,19 +5,17 @@ from django.core.files.storage import default_storage
 from django.utils import timezone
 
 
-def send_to_storage(content, modified_file_name="") -> None:
+def send_to_storage(content, alt_file_name:str ="") -> None:
+    file_name: str = alt_file_name if alt_file_name else settings.GS_BUCKET_FILE_NAME
+
     if settings.DEBUG:
         logging.info(
-            f"Sending to storage, name:{settings.GS_BUCKET_FILE_NAME}, content: {content}"
+            f"Sending to storage, name:{file_name}, content: {content}"
         )
     else:
         current_time_string = timezone.now().strftime("%Y%m%d%H%M%S")
-        if modified_file_name:
-            latest_file_name = f"{settings.modified_file_name}_latest.json"
-            date_file_name = f"{settings.modified_file_name}_{current_time_string}.json"
-        else: 
-            latest_file_name =    f"{settings.GS_BUCKET_FILE_NAME}_latest.json"  
-            date_file_name = f"{settings.GS_BUCKET_FILE_NAME}_{current_time_string}.json"
+        latest_file_name =    f"{file_name}_latest.json"  
+        date_file_name = f"{file_name}_{current_time_string}.json"
 
         date_file = default_storage.open(date_file_name, "w")
         date_file.write(content)

--- a/consvc_shepherd/storage.py
+++ b/consvc_shepherd/storage.py
@@ -12,8 +12,12 @@ def send_to_storage(content, modified_file_name="") -> None:
         )
     else:
         current_time_string = timezone.now().strftime("%Y%m%d%H%M%S")
-        latest_file_name = f"{settings.GS_BUCKET_FILE_NAME}_latest.json"
-        date_file_name = f"{settings.GS_BUCKET_FILE_NAME}_{current_time_string}.json"
+        if modified_file_name:
+            latest_file_name = f"{settings.modified_file_name}_latest.json"
+            date_file_name = f"{settings.modified_file_name}_{current_time_string}.json"
+        else: 
+            latest_file_name =    f"{settings.GS_BUCKET_FILE_NAME}_latest.json"  
+            date_file_name = f"{settings.GS_BUCKET_FILE_NAME}_{current_time_string}.json"
 
         date_file = default_storage.open(date_file_name, "w")
         date_file.write(content)


### PR DESCRIPTION
Adding env variable in settings.py for a new file name, to support the new allocation json file while supporting previous adM filtering file.

Modify [storage.py](https://github.com/mozilla-services/consvc-shepherd/blob/main/consvc_shepherd/storage.py) to have an additional parameter to set a different file name.

Made change to base call of `send_to_storage` with parameter of `file_name` defined, so that current function is maintained and `GS_BUCKET_FILE_NAME` still supplied for adM filter file. 

A couple type annotations added as well. We discussed we'd like to add them as we go and make changes to have Shepherd fall more in line with mypy typing across the board.