### PR TITLE
[DISCO-2366] Expand Automated Coverage 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 APP_DIRS := consvc_shepherd contile
+TEST_DIRS := consvc_shepherd/tests contile/tests
 COV_FAIL_UNDER := 95
 INSTALL_STAMP := .install.stamp
 POETRY := $(shell command -v poetry 2> /dev/null)
@@ -38,7 +39,7 @@ mypy: $(INSTALL_STAMP)  ##  Run mypy
 	$(POETRY) run mypy $(APP_DIRS) --config-file="pyproject.toml"
 
 .PHONY: lint
-lint: $(INSTALL_STAMP) isort black flake8 bandit mypy ##  Run various linters
+lint: $(INSTALL_STAMP) isort black flake8 bandit pydocstyle mypy ##  Run various linters
 
 .PHONY: format
 format: install  ##  Sort imports and reformat code
@@ -49,7 +50,15 @@ format: install  ##  Sort imports and reformat code
 check: install
 	$(POETRY) run python manage.py makemigrations --check --dry-run --noinput
 
+.PHONY: migrate
+migrate: install
+	$(POETRY) run python manage.py makemigrations
+	$(POETRY) run python manage.py migrate
+
 .PHONY: test
 test: migration-check
 	env DJANGO_SETTINGS_MODULE=consvc_shepherd.settings $(POETRY) run pytest --cov --cov-report=term-missing --cov-fail-under=$(COV_FAIL_UNDER)
 
+.PHONY: dev
+dev: $(INSTALL_STAMP)  ##  Run shepherd locally and reload automatically
+	$(POETRY) run python manage.py runserver

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ bandit: $(INSTALL_STAMP)  ##  Run bandit
 
 .PHONY: pydocstyle
 pydocstyle: $(INSTALL_STAMP)  ##  Run pydocstyle
-	$(POETRY) run pydocstyle $(APP_DIRS) --config="pyproject.toml"
+	$(POETRY) run pydocstyle $(APP_DIRS) --explain --config="pyproject.toml"
 
 .PHONY: mypy
 mypy: $(INSTALL_STAMP)  ##  Run mypy

--- a/consvc_shepherd/models.py
+++ b/consvc_shepherd/models.py
@@ -154,5 +154,4 @@ class PartnerAllocation(models.Model):
 
         Example: {"partner": "mozilla", "percentage": 100}
         """
-
         return {"partner": self.partner.name, "percentage": self.percentage}

--- a/consvc_shepherd/storage.py
+++ b/consvc_shepherd/storage.py
@@ -6,7 +6,7 @@ from django.core.files.storage import default_storage
 from django.utils import timezone
 
 
-def send_to_storage(content, file_name: str) -> None:
+def send_to_storage(content: str, file_name: str) -> None:
     """Send adM filter and allocation settings to GCS bucket."""
     if settings.DEBUG:
         logging.info(f"Sending to storage, name:{file_name}, content: {content}")

--- a/consvc_shepherd/tests/test_admin.py
+++ b/consvc_shepherd/tests/test_admin.py
@@ -22,7 +22,7 @@ from contile.models import Advertiser, AdvertiserUrl
 class SettingsSnapshotAdminTest(TestCase):
     """Test class for SettingsSnapshot."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up objects and variables for testing SettingsSnapshot."""
         request_factory = RequestFactory()
         self.request = request_factory.get("/admin")
@@ -50,7 +50,7 @@ class SettingsSnapshotAdminTest(TestCase):
         self.mock_storage_open.start()
         self.addCleanup(self.mock_storage_open.stop)
 
-    def test_get_read_only_fields_when_obj_exists(self):
+    def test_get_read_only_fields_when_obj_exists(self) -> None:
         """Test that expected read only fields are returned when object created."""
         obj = SettingsSnapshot.objects.create(
             name="Snapshot", settings_type=self.partner
@@ -68,18 +68,18 @@ class SettingsSnapshotAdminTest(TestCase):
             ],
         )
 
-    def test_get_read_only_fields_when_obj_does_not_exists(self):
+    def test_get_read_only_fields_when_obj_does_not_exists(self) -> None:
         """Test that read only fields return when object not created."""
         fields = self.admin.get_readonly_fields(self.request, None)
         self.assertEqual(
             fields, ["json_settings", "created_by", "launched_by", "launched_date"]
         )
 
-    def test_save_model_generates_json(self):
+    def test_save_model_generates_json(self) -> None:
         """Test that snapshot value matches expected json object."""
         self.assertEqual(SettingsSnapshot.objects.all().count(), 0)
 
-        expected_json = self.partner.to_dict()
+        expected_json: dict = self.partner.to_dict()
         self.admin.save_model(
             self.request,
             SettingsSnapshot(name="dev", settings_type=self.partner),
@@ -89,10 +89,11 @@ class SettingsSnapshotAdminTest(TestCase):
 
         self.assertEqual(SettingsSnapshot.objects.all().count(), 1)
         snapshot = SettingsSnapshot.objects.all().first()
-        validate(snapshot.json_settings, schema=self.settings_schema)
-        self.assertEqual(snapshot.json_settings, expected_json)
+        if snapshot:
+            validate(snapshot.json_settings, schema=self.settings_schema)
+            self.assertEqual(snapshot.json_settings, expected_json)
 
-    def test_publish_snapshot(self):
+    def test_publish_snapshot(self) -> None:
         """Test that publishing snapshot returns expected metadata."""
         request = mock.Mock()
         request.user = UserFactory()
@@ -104,12 +105,14 @@ class SettingsSnapshotAdminTest(TestCase):
             created_by=request.user,
         )
         publish_snapshot(None, request, SettingsSnapshot.objects.all())
-        snapshot = SettingsSnapshot.objects.get(name="Settings Snapshot")
+        snapshot: SettingsSnapshot = SettingsSnapshot.objects.get(
+            name="Settings Snapshot"
+        )
         self.assertIsNotNone(snapshot.launched_date)
 
         self.assertEqual(snapshot.launched_by, request.user)
 
-    def test_publish_snapshot_does_not_update_with_multiple_snapshots(self):
+    def test_publish_snapshot_does_not_update_with_multiple_snapshots(self) -> None:
         """Test that single publish action does not update with multiple snapshots."""
         request = mock.Mock()
         request.user = UserFactory()
@@ -129,7 +132,7 @@ class SettingsSnapshotAdminTest(TestCase):
         )
         self.assertEqual(len(snapshots), 2)
 
-    def test_publish_snapshot_does_not_launch_already_launch_snapshot(self):
+    def test_publish_snapshot_does_not_launch_already_launch_snapshot(self) -> None:
         """Test that publish snapshot action does not launch pre-existing snapshot."""
         request = mock.Mock()
         request.user = UserFactory()
@@ -148,7 +151,7 @@ class SettingsSnapshotAdminTest(TestCase):
         )
         self.assertEqual(len(snapshots), 0)
 
-    def test_snapshot_cannot_be_deleted_when_launched(self):
+    def test_snapshot_cannot_be_deleted_when_launched(self) -> None:
         """Test that snapshot cannot be deleted once launched."""
         request = mock.Mock()
         request.user = UserFactory()
@@ -161,7 +164,7 @@ class SettingsSnapshotAdminTest(TestCase):
         )
         self.assertFalse(self.admin.has_delete_permission(request, snapshot))
 
-    def test_snapshot_can_be_deleted_when_unlaunched(self):
+    def test_snapshot_can_be_deleted_when_unlaunched(self) -> None:
         """Test that snapshot can be deleted when unlaunched."""
         request = mock.Mock()
         request.user = UserFactory()
@@ -176,7 +179,7 @@ class SettingsSnapshotAdminTest(TestCase):
 class AllocationSettingAdminTest(TestCase):
     """Test class for AllocationSetting."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up objects and variables for testing AllocationSetting."""
         request_factory = RequestFactory()
         self.request = request_factory.get("/admin/consvc_shepherd/allocationsetting/")
@@ -208,7 +211,7 @@ class AllocationSettingAdminTest(TestCase):
         self.mock_storage_open.start()
         self.addCleanup(self.mock_storage_open.stop)
 
-    def test_publish_allocation(self):
+    def test_publish_allocation(self) -> None:
         """Test that publish action of allocation settings returns expected AllocationSetting."""
         request = mock.Mock()
         expected: dict = {

--- a/consvc_shepherd/tests/test_models.py
+++ b/consvc_shepherd/tests/test_models.py
@@ -30,6 +30,7 @@ class TestAllocationSettingModel(TestCase):
             ],
         }
         self.assertEqual(position1_alloc.to_dict(), expected_result)
+        self.assertEqual(str(position1_alloc), "Allocation Position : 1")
 
 
 class TestPartnerAllocationModel(TestCase):

--- a/contile/admin.py
+++ b/contile/admin.py
@@ -39,6 +39,7 @@ class PartnerListAdmin(admin.ModelAdmin):
     model = Partner
 
     def delete_queryset(self, request, queryset):
+        """Delete given PartnerListAdmin entry."""
         super(PartnerListAdmin, self).delete_queryset(request, queryset)
         messages.warning(
             request,

--- a/contile/admin.py
+++ b/contile/admin.py
@@ -38,7 +38,7 @@ class PartnerListAdmin(admin.ModelAdmin):
 
     model = Partner
 
-    def delete_queryset(self, request, queryset):
+    def delete_queryset(self, request, queryset) -> None:
         """Delete given PartnerListAdmin entry."""
         super(PartnerListAdmin, self).delete_queryset(request, queryset)
         messages.warning(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ mypy = "^1.2.0"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.isort]
+profile = "black"
+skip_gitignore = true
+
 [tool.bandit]
 # skips asserts
 # B101: https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html#


### PR DESCRIPTION
## References

JIRA: [DISCO-2366](https://mozilla-hub.atlassian.net/browse/DISCO-2366)
GitHub: [#107](https://github.com/mozilla-services/consvc-shepherd/issues/107)


## Description

Shepherd is missing some of the useful features to verify test coverage and conventions we have for Merino. A simple update of the pyproject.toml and update of Poetry dependencies will give us access to:

    Test coverage percentage reporting

    Addition of mypy static typing 

    pydocstyle 

    Test coverage report

    Individual commands for flake9, bandit, black, isort, mypy, pydocstyle

There is also an error with the local make call to test and it only runs with ./manage.py test, which doesn’t provide the same clear output.

Note: many features covered by other individual PRs for each tool.

[DISCO-2366]: https://mozilla-hub.atlassian.net/browse/DISCO-2366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ