### PR TITLE
[DISCO-2159] Add mypy/types to Shepherd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ mypy: $(INSTALL_STAMP)  ##  Run mypy
 	$(POETRY) run mypy $(APP_DIRS) --config-file="pyproject.toml"
 
 .PHONY: lint
-lint: $(INSTALL_STAMP) isort black flake8 bandit ##  Run various linters
+lint: $(INSTALL_STAMP) isort black flake8 bandit mypy ##  Run various linters
 
 .PHONY: format
 format: install  ##  Sort imports and reformat code

--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,32 @@ $(INSTALL_STAMP): pyproject.toml poetry.lock
 	$(POETRY) install
 	touch $(INSTALL_STAMP)
 
+.PHONY: isort
+isort: $(INSTALL_STAMP)  ##  Run isort
+	$(POETRY) run isort --check-only $(APP_DIRS) --profile black
+
+.PHONY: black
+black: $(INSTALL_STAMP)  ##  Run black
+	$(POETRY) run black --quiet --diff --check $(APP_DIRS)
+
+.PHONY: flake8
+flake8: $(INSTALL_STAMP)  ##  Run flake8
+	$(POETRY) run flake8 $(APP_DIRS) --ignore=E203,E302,E501,E701
+
+.PHONY: bandit
+bandit: $(INSTALL_STAMP)  ##  Run bandit ##CHECK -c "pyproject.toml"
+	$(POETRY) run bandit --quiet -r $(APP_DIRS) 
+
+.PHONY: mypy
+mypy: $(INSTALL_STAMP)  ##  Run mypy
+	$(POETRY) run mypy $(APP_DIRS) --config-file="pyproject.toml"
+
 .PHONY: mypy
 mypy: $(INSTALL_STAMP)  ##  Run mypy
 	$(POETRY) run mypy $(APP_DIRS) --config-file="pyproject.toml"
 
 .PHONY: lint
-lint: install  ##  Run various linters
-	$(POETRY) run isort --check-only $(APP_DIRS) --profile black
-	$(POETRY) run black --quiet --diff --check $(APP_DIRS)
-	$(POETRY) run flake8 $(APP_DIRS) --ignore=E203,E302,E501,E701
-	$(POETRY) run bandit --quiet -r $(APP_DIRS)
+lint: $(INSTALL_STAMP) isort black flake8 bandit ##  Run various linters
 
 .PHONY: format
 format: install  ##  Sort imports and reformat code

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ $(INSTALL_STAMP): pyproject.toml poetry.lock
 	$(POETRY) install
 	touch $(INSTALL_STAMP)
 
+.PHONY: mypy
+mypy: $(INSTALL_STAMP)  ##  Run mypy
+	$(POETRY) run mypy $(APP_DIRS) --config-file="pyproject.toml"
+
 .PHONY: lint
 lint: install  ##  Run various linters
 	$(POETRY) run isort --check-only $(APP_DIRS) --profile black

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,6 @@ bandit: $(INSTALL_STAMP)  ##  Run bandit ##CHECK -c "pyproject.toml"
 mypy: $(INSTALL_STAMP)  ##  Run mypy
 	$(POETRY) run mypy $(APP_DIRS) --config-file="pyproject.toml"
 
-.PHONY: mypy
-mypy: $(INSTALL_STAMP)  ##  Run mypy
-	$(POETRY) run mypy $(APP_DIRS) --config-file="pyproject.toml"
-
 .PHONY: lint
 lint: $(INSTALL_STAMP) isort black flake8 bandit mypy ##  Run various linters
 

--- a/consvc_shepherd/models.py
+++ b/consvc_shepherd/models.py
@@ -1,25 +1,34 @@
 from django.contrib.auth import get_user_model
 from django.db import models
+from django.db.models import (
+    CharField,
+    DateTimeField,
+    ForeignKey,
+    IntegerField,
+    JSONField,
+)
 
 from contile.models import Partner
 
 
 class SettingsSnapshot(models.Model):
-    name = models.CharField(max_length=128)
-    settings_type = models.ForeignKey(Partner, on_delete=models.SET_NULL, null=True)
-    json_settings = models.JSONField(blank=True, null=True)
-    created_by = models.ForeignKey(
+    name: CharField = models.CharField(max_length=128)
+    settings_type: ForeignKey = models.ForeignKey(
+        Partner, on_delete=models.SET_NULL, null=True
+    )
+    json_settings: JSONField = models.JSONField(blank=True, null=True)
+    created_by: ForeignKey = models.ForeignKey(
         get_user_model(), on_delete=models.CASCADE, blank=True, null=True
     )
-    created_on = models.DateTimeField(auto_now_add=True)
-    launched_by = models.ForeignKey(
+    created_on: DateTimeField = models.DateTimeField(auto_now_add=True)
+    launched_by: ForeignKey = models.ForeignKey(
         get_user_model(),
         related_name="launched_by",
         on_delete=models.CASCADE,
         blank=True,
         null=True,
     )
-    launched_date = models.DateTimeField(blank=True, null=True)
+    launched_date: DateTimeField = models.DateTimeField(blank=True, null=True)
 
     def __str__(self):
         return f"{self.name}: {self.created_on.strftime('%Y-%m-%d %H:%M')}"
@@ -31,7 +40,7 @@ class SettingsSnapshot(models.Model):
 class AllocationSetting(models.Model):
     """Class that holds information for Allocation"""
 
-    position = models.IntegerField(unique=True)
+    position: IntegerField = models.IntegerField(unique=True)
 
     def __str__(self):
         return f"Allocation Position : {self.position}"
@@ -40,8 +49,10 @@ class AllocationSetting(models.Model):
 class PartnerAllocation(models.Model):
     """Class that holds information about Partner Specific Allocation"""
 
-    allocationPosition = models.ForeignKey(
+    allocationPosition: ForeignKey = models.ForeignKey(
         AllocationSetting, on_delete=models.CASCADE, related_name="partner_allocations"
     )
-    partner = models.ForeignKey(Partner, on_delete=models.SET_NULL, null=True)
-    percentage = models.IntegerField()
+    partner: ForeignKey = models.ForeignKey(
+        Partner, on_delete=models.SET_NULL, null=True
+    )
+    percentage: IntegerField = models.IntegerField()

--- a/consvc_shepherd/tests/factories.py
+++ b/consvc_shepherd/tests/factories.py
@@ -6,9 +6,9 @@ faker = FakerFactory.create()
 
 
 class UserFactory(factory.django.DjangoModelFactory):
-    first_name = factory.LazyAttribute(lambda o: faker.first_name())
-    last_name = factory.LazyAttribute(lambda o: faker.last_name())
-    email = factory.LazyAttribute(lambda o: faker.company_email())
+    first_name = factory.LazyAttribute(lambda o: faker.first_name())  # type: ignore [attr-defined]
+    last_name = factory.LazyAttribute(lambda o: faker.last_name())  # type: ignore [attr-defined]
+    email = factory.LazyAttribute(lambda o: faker.company_email())  # type: ignore [attr-defined]
     username = factory.LazyAttribute(lambda o: o.email)
 
     class Meta:

--- a/consvc_shepherd/tests/test_admin.py
+++ b/consvc_shepherd/tests/test_admin.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+import mock  # type: ignore [import]
 from django.contrib.admin.sites import AdminSite
 from django.test import RequestFactory, TestCase
 from django.utils import timezone

--- a/contile/models.py
+++ b/contile/models.py
@@ -5,12 +5,14 @@ from django.db import models
 from django.db.models import BooleanField, CharField, ForeignKey
 from django_countries.fields import CountryField
 
-MATCHING_CHOICES = (
+MATCHING_CHOICES: tuple[tuple[bool, str], tuple[bool, str]] = (
     (True, "exact"),
     (False, "prefix"),
 )
-INVALID_PREFIX_PATH_ERROR = "Prefix paths can't be just '/' but needs to end with '/' "
-INVALID_PATH_ERROR = "All paths need to start '/'"
+INVALID_PREFIX_PATH_ERROR: str = (
+    "Prefix paths can't be just '/' but needs to end with '/' "
+)
+INVALID_PATH_ERROR: str = "All paths need to start '/'"
 
 
 class Partner(models.Model):

--- a/contile/models.py
+++ b/contile/models.py
@@ -42,14 +42,14 @@ class Advertiser(models.Model):
     def to_dict(self) -> dict[str, Any]:
         result: dict = {}
         geo_domain_combos = (
-            self.ad_urls.all()
+            self.ad_urls.all()  # type: ignore [attr-defined]
             .values_list("geo", "domain")
             .distinct()
             .order_by("geo", "domain")
         )
 
         for geo, domain in geo_domain_combos:
-            ad_urls = self.ad_urls.filter(geo=geo, domain=domain).order_by("path")
+            ad_urls = self.ad_urls.filter(geo=geo, domain=domain).order_by("path")  # type: ignore [attr-defined]
             paths = [
                 {
                     "value": ad_url.path,
@@ -89,7 +89,7 @@ class AdvertiserUrl(models.Model):
         if not self.path.startswith("/"):
             raise ValidationError(INVALID_PATH_ERROR)
 
-        if self.get_matching_display() == "prefix" and (
+        if self.get_matching_display() == "prefix" and (  # type: ignore [attr-defined]
             self.path == "/" or not self.path.endswith("/")
         ):
             raise ValidationError(INVALID_PREFIX_PATH_ERROR)

--- a/contile/models.py
+++ b/contile/models.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models import BooleanField, CharField, ForeignKey
 from django_countries.fields import CountryField
 
 MATCHING_CHOICES = (
@@ -11,7 +14,7 @@ INVALID_PATH_ERROR = "All paths need to start '/'"
 
 
 class Partner(models.Model):
-    name = models.CharField(max_length=128)
+    name: CharField = models.CharField(max_length=128)
 
     def to_dict(self):
         partner_dict = {}
@@ -25,8 +28,8 @@ class Partner(models.Model):
 
 
 class Advertiser(models.Model):
-    name = models.CharField(max_length=128)
-    partner = models.ForeignKey(
+    name: CharField = models.CharField(max_length=128)
+    partner: ForeignKey = models.ForeignKey(
         Partner,
         blank=False,
         null=False,
@@ -34,8 +37,8 @@ class Advertiser(models.Model):
         on_delete=models.CASCADE,
     )
 
-    def to_dict(self):
-        result = {}
+    def to_dict(self) -> dict[str, Any]:
+        result: dict = {}
         geo_domain_combos = (
             self.ad_urls.all()
             .values_list("geo", "domain")
@@ -63,7 +66,7 @@ class Advertiser(models.Model):
 
 
 class AdvertiserUrl(models.Model):
-    advertiser = models.ForeignKey(
+    advertiser: ForeignKey = models.ForeignKey(
         Advertiser,
         blank=False,
         null=False,
@@ -71,10 +74,10 @@ class AdvertiserUrl(models.Model):
         on_delete=models.CASCADE,
     )
 
-    geo = CountryField()
-    domain = models.CharField(max_length=255)
-    path = models.CharField(max_length=128)
-    matching = models.BooleanField(choices=MATCHING_CHOICES, default=True)
+    geo: CountryField = CountryField()
+    domain: CharField = models.CharField(max_length=255)
+    path: CharField = models.CharField(max_length=128)
+    matching: BooleanField = models.BooleanField(choices=MATCHING_CHOICES, default=True)
 
     def __str__(self):
         return f"{self.geo.code}: {self.domain} {self.path}"
@@ -94,7 +97,7 @@ class AdvertiserUrl(models.Model):
         return super(AdvertiserUrl, self).save(*args, **kwargs)
 
 
-def is_valid_host(host):
+def is_valid_host(host) -> None:
 
     if not all([h.isalnum() or h in [".", "-"] for h in host]):
         raise ValidationError(

--- a/poetry.lock
+++ b/poetry.lock
@@ -903,46 +903,42 @@ test = ["pytest (<5.4)", "pytest-cov"]
 
 [[package]]
 name = "mypy"
-version = "0.991"
+version = "1.2.0"
 description = "Optional static typing for Python"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "mypy-0.991-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab"},
-    {file = "mypy-0.991-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0714258640194d75677e86c786e80ccf294972cc76885d3ebbb560f11db0003d"},
-    {file = "mypy-0.991-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0c8f3be99e8a8bd403caa8c03be619544bc2c77a7093685dcf308c6b109426c6"},
-    {file = "mypy-0.991-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc9ec663ed6c8f15f4ae9d3c04c989b744436c16d26580eaa760ae9dd5d662eb"},
-    {file = "mypy-0.991-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4307270436fd7694b41f913eb09210faff27ea4979ecbcd849e57d2da2f65305"},
-    {file = "mypy-0.991-cp310-cp310-win_amd64.whl", hash = "sha256:901c2c269c616e6cb0998b33d4adbb4a6af0ac4ce5cd078afd7bc95830e62c1c"},
-    {file = "mypy-0.991-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d13674f3fb73805ba0c45eb6c0c3053d218aa1f7abead6e446d474529aafc372"},
-    {file = "mypy-0.991-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1c8cd4fb70e8584ca1ed5805cbc7c017a3d1a29fb450621089ffed3e99d1857f"},
-    {file = "mypy-0.991-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:209ee89fbb0deed518605edddd234af80506aec932ad28d73c08f1400ef80a33"},
-    {file = "mypy-0.991-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37bd02ebf9d10e05b00d71302d2c2e6ca333e6c2a8584a98c00e038db8121f05"},
-    {file = "mypy-0.991-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:26efb2fcc6b67e4d5a55561f39176821d2adf88f2745ddc72751b7890f3194ad"},
-    {file = "mypy-0.991-cp311-cp311-win_amd64.whl", hash = "sha256:3a700330b567114b673cf8ee7388e949f843b356a73b5ab22dd7cff4742a5297"},
-    {file = "mypy-0.991-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1f7d1a520373e2272b10796c3ff721ea1a0712288cafaa95931e66aa15798813"},
-    {file = "mypy-0.991-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:641411733b127c3e0dab94c45af15fea99e4468f99ac88b39efb1ad677da5711"},
-    {file = "mypy-0.991-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:3d80e36b7d7a9259b740be6d8d906221789b0d836201af4234093cae89ced0cd"},
-    {file = "mypy-0.991-cp37-cp37m-win_amd64.whl", hash = "sha256:e62ebaad93be3ad1a828a11e90f0e76f15449371ffeecca4a0a0b9adc99abcef"},
-    {file = "mypy-0.991-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:b86ce2c1866a748c0f6faca5232059f881cda6dda2a893b9a8373353cfe3715a"},
-    {file = "mypy-0.991-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ac6e503823143464538efda0e8e356d871557ef60ccd38f8824a4257acc18d93"},
-    {file = "mypy-0.991-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0cca5adf694af539aeaa6ac633a7afe9bbd760df9d31be55ab780b77ab5ae8bf"},
-    {file = "mypy-0.991-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a12c56bf73cdab116df96e4ff39610b92a348cc99a1307e1da3c3768bbb5b135"},
-    {file = "mypy-0.991-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:652b651d42f155033a1967739788c436491b577b6a44e4c39fb340d0ee7f0d70"},
-    {file = "mypy-0.991-cp38-cp38-win_amd64.whl", hash = "sha256:4175593dc25d9da12f7de8de873a33f9b2b8bdb4e827a7cae952e5b1a342e243"},
-    {file = "mypy-0.991-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:98e781cd35c0acf33eb0295e8b9c55cdbef64fcb35f6d3aa2186f289bed6e80d"},
-    {file = "mypy-0.991-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6d7464bac72a85cb3491c7e92b5b62f3dcccb8af26826257760a552a5e244aa5"},
-    {file = "mypy-0.991-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c9166b3f81a10cdf9b49f2d594b21b31adadb3d5e9db9b834866c3258b695be3"},
-    {file = "mypy-0.991-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8472f736a5bfb159a5e36740847808f6f5b659960115ff29c7cecec1741c648"},
-    {file = "mypy-0.991-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5e80e758243b97b618cdf22004beb09e8a2de1af481382e4d84bc52152d1c476"},
-    {file = "mypy-0.991-cp39-cp39-win_amd64.whl", hash = "sha256:74e259b5c19f70d35fcc1ad3d56499065c601dfe94ff67ae48b85596b9ec1461"},
-    {file = "mypy-0.991-py3-none-any.whl", hash = "sha256:de32edc9b0a7e67c2775e574cb061a537660e51210fbf6006b0b36ea695ae9bb"},
-    {file = "mypy-0.991.tar.gz", hash = "sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06"},
+    {file = "mypy-1.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:701189408b460a2ff42b984e6bd45c3f41f0ac9f5f58b8873bbedc511900086d"},
+    {file = "mypy-1.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fe91be1c51c90e2afe6827601ca14353bbf3953f343c2129fa1e247d55fd95ba"},
+    {file = "mypy-1.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d26b513225ffd3eacece727f4387bdce6469192ef029ca9dd469940158bc89e"},
+    {file = "mypy-1.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3a2d219775a120581a0ae8ca392b31f238d452729adbcb6892fa89688cb8306a"},
+    {file = "mypy-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:2e93a8a553e0394b26c4ca683923b85a69f7ccdc0139e6acd1354cc884fe0128"},
+    {file = "mypy-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3efde4af6f2d3ccf58ae825495dbb8d74abd6d176ee686ce2ab19bd025273f41"},
+    {file = "mypy-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:695c45cea7e8abb6f088a34a6034b1d273122e5530aeebb9c09626cea6dca4cb"},
+    {file = "mypy-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0e9464a0af6715852267bf29c9553e4555b61f5904a4fc538547a4d67617937"},
+    {file = "mypy-1.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8293a216e902ac12779eb7a08f2bc39ec6c878d7c6025aa59464e0c4c16f7eb9"},
+    {file = "mypy-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:f46af8d162f3d470d8ffc997aaf7a269996d205f9d746124a179d3abe05ac602"},
+    {file = "mypy-1.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:031fc69c9a7e12bcc5660b74122ed84b3f1c505e762cc4296884096c6d8ee140"},
+    {file = "mypy-1.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:390bc685ec209ada4e9d35068ac6988c60160b2b703072d2850457b62499e336"},
+    {file = "mypy-1.2.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:4b41412df69ec06ab141808d12e0bf2823717b1c363bd77b4c0820feaa37249e"},
+    {file = "mypy-1.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:4e4a682b3f2489d218751981639cffc4e281d548f9d517addfd5a2917ac78119"},
+    {file = "mypy-1.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a197ad3a774f8e74f21e428f0de7f60ad26a8d23437b69638aac2764d1e06a6a"},
+    {file = "mypy-1.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c9a084bce1061e55cdc0493a2ad890375af359c766b8ac311ac8120d3a472950"},
+    {file = "mypy-1.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaeaa0888b7f3ccb7bcd40b50497ca30923dba14f385bde4af78fac713d6d6f6"},
+    {file = "mypy-1.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bea55fc25b96c53affab852ad94bf111a3083bc1d8b0c76a61dd101d8a388cf5"},
+    {file = "mypy-1.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:4c8d8c6b80aa4a1689f2a179d31d86ae1367ea4a12855cc13aa3ba24bb36b2d8"},
+    {file = "mypy-1.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:70894c5345bea98321a2fe84df35f43ee7bb0feec117a71420c60459fc3e1eed"},
+    {file = "mypy-1.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4a99fe1768925e4a139aace8f3fb66db3576ee1c30b9c0f70f744ead7e329c9f"},
+    {file = "mypy-1.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:023fe9e618182ca6317ae89833ba422c411469156b690fde6a315ad10695a521"},
+    {file = "mypy-1.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4d19f1a239d59f10fdc31263d48b7937c585810288376671eaf75380b074f238"},
+    {file = "mypy-1.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:2de7babe398cb7a85ac7f1fd5c42f396c215ab3eff731b4d761d68d0f6a80f48"},
+    {file = "mypy-1.2.0-py3-none-any.whl", hash = "sha256:d8e9187bfcd5ffedbe87403195e1fc340189a68463903c39e2b63307c9fa0394"},
+    {file = "mypy-1.2.0.tar.gz", hash = "sha256:f70a40410d774ae23fcb4afbbeca652905a04de7948eaf0b1789c8d1426b72d1"},
 ]
 
 [package.dependencies]
-mypy-extensions = ">=0.4.3"
+mypy-extensions = ">=1.0.0"
 typing-extensions = ">=3.10"
 
 [package.extras]
@@ -953,14 +949,14 @@ reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
-version = "0.4.3"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.5"
 files = [
-    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
-    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
 ]
 
 [[package]]
@@ -1718,4 +1714,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "caa6b420584c750238d32af2a22ea42cbbf0c859ee417d6c6161cb02d21622a1"
+content-hash = "74309f9deaceb30dc106d3d97c4a6c6bd04e399f6c6c6b2692be28f322122937"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,22 @@ pytest-django = "^4.5.2"
 pytest-cov = "^4.0.0"
 requests = "^2.28.1"
 selenium = "^4.8.0"
+mypy = "^1.2.0"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.mypy]
+python_version = "3.11"
+disallow_untyped_calls = true
+follow_imports = "normal"
+ignore_missing_imports = true
+pretty = true
+show_error_codes = true
+strict_optional = true
+warn_no_return = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unused_ignores = true
+warn_unreachable = true


### PR DESCRIPTION
## References

JIRA: [DISCO-2159](https://mozilla-hub.atlassian.net/browse/DISCO-2366)
GitHub: [#109 ](https://github.com/mozilla-services/consvc-shepherd/issues/109)


## Description

Implement the addition of mypy as a Makefile command and that all files conform to correct typing.

Requires:
Pyproject.toml updates
Test build with poetry install and ensure no dependency issues with mypy version (poetry lock --no-update)
Updates to makefile to run mypy checks
Resolve any typing errors mypy throws
Add process to lint checks when verifying code quality 
Add ignore annotations to inaccurate typing errors

[DISCO-2159]: https://mozilla-hub.atlassian.net/browse/DISCO-2159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ