### PR TITLE
[DISCO-2399] Add Auto-generated Documentation to Django Admin

### DIFF
--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -120,10 +120,8 @@ DEFAULT_AUTO_FIELD: str = "django.db.models.BigAutoField"
 
 DEFAULT_FILE_STORAGE: str = "storages.backends.gcloud.GoogleCloudStorage"
 GS_BUCKET_NAME = env("GS_BUCKET_NAME", default="")
-GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME",
-                          default="settings_from_shepherd")
-ALLOCATION_FILE_NAME: str = env(
-    "ALLOCATION_FILE_NAME", default="allocation_file")
+GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME", default="settings_from_shepherd")
+ALLOCATION_FILE_NAME: str = env("ALLOCATION_FILE_NAME", default="allocation_file")
 
 LOGGING: dict[str, Any] = {
     "version": 1,

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS: list[str] = [
     "consvc_shepherd",
     "contile",
     "django.contrib.admin",
+    "django.contrib.admindocs",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
@@ -119,8 +120,10 @@ DEFAULT_AUTO_FIELD: str = "django.db.models.BigAutoField"
 
 DEFAULT_FILE_STORAGE: str = "storages.backends.gcloud.GoogleCloudStorage"
 GS_BUCKET_NAME = env("GS_BUCKET_NAME", default="")
-GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME", default="settings_from_shepherd")
-ALLOCATION_FILE_NAME: str = env("ALLOCATION_FILE_NAME", default="allocation_file")
+GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME",
+                          default="settings_from_shepherd")
+ALLOCATION_FILE_NAME: str = env(
+    "ALLOCATION_FILE_NAME", default="allocation_file")
 
 LOGGING: dict[str, Any] = {
     "version": 1,

--- a/consvc_shepherd/urls.py
+++ b/consvc_shepherd/urls.py
@@ -13,13 +13,14 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
-from django.urls import path
+from django.contrib import admin, admindocs
+from django.urls import path, include
 
 from consvc_shepherd.models import AllocationSetting
 from consvc_shepherd.views import AllocationSettingList, TableOverview
 
 urlpatterns = [
+    path('admin/doc/', include('django.contrib.admindocs.urls')),
     path("admin/", admin.site.urls),
     path(
         "allocation/",

--- a/consvc_shepherd/urls.py
+++ b/consvc_shepherd/urls.py
@@ -13,14 +13,14 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin, admindocs
-from django.urls import path, include
+from django.contrib import admin
+from django.urls import include, path
 
 from consvc_shepherd.models import AllocationSetting
 from consvc_shepherd.views import AllocationSettingList, TableOverview
 
 urlpatterns = [
-    path('admin/doc/', include('django.contrib.admindocs.urls')),
+    path("admin/doc/", include("django.contrib.admindocs.urls")),
     path("admin/", admin.site.urls),
     path(
         "allocation/",

--- a/poetry.lock
+++ b/poetry.lock
@@ -510,6 +510,18 @@ flask = ["blinker", "flask"]
 sanic = ["sanic"]
 
 [[package]]
+name = "docutils"
+version = "0.20"
+description = "Docutils -- Python Documentation Utilities"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "docutils-0.20-py3-none-any.whl", hash = "sha256:a428f10de4de4774389734c986a01b4af2d802d26717108b0f1b9356862937c5"},
+    {file = "docutils-0.20.tar.gz", hash = "sha256:f75a5a52fbcacd81b47e42888ad2b380748aaccfb3f13af0fe69deb759f01eb6"},
+]
+
+[[package]]
 name = "factory-boy"
 version = "3.2.1"
 description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
@@ -1744,4 +1756,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "7e75abe2e1224de9a13de5349d8a7a6541dd6ea835a901dd8bb426f3e7dd36fe"
+content-hash = "1e4e7378c3388e04e455e23a134b615e58c6672123351084290bff65fed449b9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,14 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-django = "^4.1.9"
+django = "^4.2.1"
 django-countries = "^7.5"
 django-environ = "^0.9.0"
 django-polymorphic = "^3.1.0"
 django-storages = {extras = ["google"], version = "^1.13.1"}
 django-stubs = "^1.13.1"
 dockerflow = "^2022.8.0"
+docutils = "^0.20"
 google-auth = {extras = ["pyopenssl"], version = "^2.15.0"}
 sentry-sdk = "^1.14.0"
 psycopg2-binary = "^2.9.5"


### PR DESCRIPTION
## References

JIRA: [DISCO-2399](https://mozilla-hub.atlassian.net/browse/DISCO-2399)
GitHub: [#118 ](https://github.com/mozilla-services/consvc-shepherd/issues/118)

## Description
Since the addition of pydocstyle, we can take advantage of Django’s capabilities to generate documentation. This allows for clean, easy to read documentation of all the views and models. This can be accessed at the admin/doc endpoint.

![Screen Shot 2023-05-15 at 4 58 37 PM](https://github.com/mozilla-services/consvc-shepherd/assets/35045299/31acb08b-b34e-471b-a461-af249d97fe4c)

![Screen Shot 2023-05-15 at 4 58 50 PM](https://github.com/mozilla-services/consvc-shepherd/assets/35045299/676a1853-f096-4d30-b64f-79d3875698bb)

![Screen Shot 2023-05-15 at 4 58 57 PM](https://github.com/mozilla-services/consvc-shepherd/assets/35045299/84d825e5-fede-40b2-805f-83f487917b96)

See:
[Django documentation](https://docs.djangoproject.com/en/4.2/ref/contrib/admin/admindocs/)

 [docutils](https://pypi.org/project/docutils/)

Acceptance Criteria:

Add code to generate application docs/runbook at admin/doc endpoint.

Add docutils


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [ ] Functional and performance test coverage has been expanded and maintained (if applicable).

[DISCO-2399]: https://mozilla-hub.atlassian.net/browse/DISCO-2399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ