### PR TITLE
[DISCO-2407] Shepherd Sentry Setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ flake8: $(INSTALL_STAMP)  ##  Run flake8
 
 .PHONY: bandit
 bandit: $(INSTALL_STAMP)  ##  Run bandit
-	$(POETRY) run bandit --quiet -r $(APP_DIRS) 
+	$(POETRY) run bandit --quiet -r $(APP_DIRS) -c "pyproject.toml"
 
 .PHONY: pydocstyle
 pydocstyle: $(INSTALL_STAMP)  ##  Run pydocstyle

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -153,7 +153,7 @@ LOGGING: dict[str, Any] = {
 # Sentry Setup
 SENTRY_DSN = env("SENTRY_DSN", default=None)
 # Any of "release", "debug", or "disabled". Using "debug" will enable logging for Sentry.
-SENTRY_MODE = env("SENTRY_DEBUG_MODE", default="release")
+SENTRY_MODE = env("SENTRY_DEBUG_MODE", default="disabled")
 SENTRY_TRACE_SAMPLE_RATE = env("SENTRY_TRACE_SAMPLE_RATE", default=1.0)
 SENTRY_ENV = env("SENTRY_ENV", default=None)
 

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -153,7 +153,7 @@ LOGGING: dict[str, Any] = {
 # Sentry Setup
 SENTRY_DSN = env("SENTRY_DSN", default=None)
 # Any of "release", "debug", or "disabled". Using "debug" will enable logging for Sentry.
-SENTRY_MODE = env("SENTRY_DEBUG_MODE", default="disabled")
+SENTRY_MODE = env("SENTRY_DEBUG_MODE", default="release")
 SENTRY_TRACE_SAMPLE_RATE = env("SENTRY_TRACE_SAMPLE_RATE", default=1.0)
 SENTRY_ENV = env("SENTRY_ENV", default=None)
 

--- a/consvc_shepherd/tests/test_version.py
+++ b/consvc_shepherd/tests/test_version.py
@@ -1,0 +1,48 @@
+"""Unit tests for the version.py utility module."""
+import json
+import pathlib
+
+import pytest
+
+from consvc_shepherd.version import Version, fetch_app_version_from_file
+
+
+def test_fetch_app_version_from_file() -> None:
+    """Happy path test for fetch_app_version_from_file()."""
+    expected_information = {
+        "source": "https://github.com/mozilla-services/consvc-shepherd",
+        "version": "dev",
+        "commit": "TBD",
+        "build": "TBD",
+    }
+
+    version = fetch_app_version_from_file()
+    assert version == Version(**expected_information)
+
+
+def test_fetch_app_version_from_file_invalid_path() -> None:
+    """Test that the 'version.json' file cannot be read when provided
+    an invalid path, raising a FileNotFoundError.
+    """
+    with pytest.raises(FileNotFoundError) as excinfo:
+        fetch_app_version_from_file(pathlib.Path("invalid"))
+
+    assert "No such file or directory: 'invalid/version.json'" in str(excinfo.value)
+
+
+@pytest.fixture(name="dir_containing_incorrect_file")
+def fixture_dir_containing_incorrect_file(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a version.json file that does not match the Version model."""
+    version_file = tmp_path / "version.json"
+    version_file.write_text(
+        json.dumps(
+            {
+                "source": "https://github.com/mozilla-services/consvc-shepherd",
+                "version": "dev",
+                "commit": "TBD",
+                "build": "TBD",
+                "incorrect": "this should not be here",
+            }
+        )
+    )
+    return tmp_path

--- a/consvc_shepherd/version.py
+++ b/consvc_shepherd/version.py
@@ -1,0 +1,30 @@
+"""Versioning utility module"""
+import json
+import pathlib
+from dataclasses import dataclass
+
+
+@dataclass
+class Version:
+    """Model for version.json data"""
+
+    source: str
+    version: str
+    commit: str
+    build: str
+
+
+def fetch_app_version_from_file(
+    app_root_path: pathlib.Path = pathlib.Path.cwd(),
+) -> Version:
+    """Fetch the content of the version.json file, which contains the SHA-1 hash
+    commit value, repo source url, version, and CI build values.
+    During deployment, this file is written and values are populated for
+    the current version of Shepherd in production and staging.
+    """
+    version_file: pathlib.Path = app_root_path / "version.json"
+
+    # pathlib has the 'read_text()' function that opens the file, reads it
+    # and closes the file like a context manager. Uses built-in open() function.
+    version_file_content: dict = json.loads(version_file.read_text())
+    return Version(**version_file_content)

--- a/poetry.lock
+++ b/poetry.lock
@@ -62,6 +62,7 @@ colorama = {version = ">=0.3.9", markers = "platform_system == \"Windows\""}
 GitPython = ">=1.0.1"
 PyYAML = ">=5.3.1"
 stevedore = ">=1.20.0"
+toml = {version = "*", optional = true, markers = "extra == \"toml\""}
 
 [package.extras]
 test = ["beautifulsoup4 (>=4.8.0)", "coverage (>=4.5.4)", "fixtures (>=3.0.0)", "flake8 (>=4.0.0)", "pylint (==1.9.4)", "stestr (>=2.5.0)", "testscenarios (>=0.5.0)", "testtools (>=2.3.0)", "toml"]
@@ -1625,6 +1626,18 @@ files = [
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1760,4 +1773,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "87e1747ef15298ba1fd8a081acd9f500ea46822812a9e248deeec6fed76fe12c"
+content-hash = "1abb028a27d1bbec847ceacd18b983553e914909a3d1a41b8ed186888ef95fc5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1437,21 +1437,21 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.28.1"
+version = "2.31.0"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = ">=3.7, <4"
+python-versions = ">=3.7"
 files = [
-    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
-    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<3"
+charset-normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<1.27"
+urllib3 = ">=1.21.1,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
@@ -1773,4 +1773,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "1abb028a27d1bbec847ceacd18b983553e914909a3d1a41b8ed186888ef95fc5"
+content-hash = "9063ab8603d577c61bd475af0c057c815417067a107a69c48abf3b40b919939c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1491,22 +1491,23 @@ urllib3 = {version = ">=1.26,<2.0", extras = ["socks"]}
 
 [[package]]
 name = "sentry-sdk"
-version = "1.14.0"
+version = "1.23.1"
 description = "Python client for Sentry (https://sentry.io)"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "sentry-sdk-1.14.0.tar.gz", hash = "sha256:273fe05adf052b40fd19f6d4b9a5556316807246bd817e5e3482930730726bb0"},
-    {file = "sentry_sdk-1.14.0-py2.py3-none-any.whl", hash = "sha256:72c00322217d813cf493fe76590b23a757e063ff62fec59299f4af7201dd4448"},
+    {file = "sentry-sdk-1.23.1.tar.gz", hash = "sha256:0300fbe7a07b3865b3885929fb863a68ff01f59e3bcfb4e7953d0bf7fd19c67f"},
+    {file = "sentry_sdk-1.23.1-py2.py3-none-any.whl", hash = "sha256:a884e2478e0b055776ea2b9234d5de9339b4bae0b3a5e74ae43d131db8ded27e"},
 ]
 
 [package.dependencies]
 certifi = "*"
-urllib3 = {version = ">=1.26.11", markers = "python_version >= \"3.6\""}
+urllib3 = {version = ">=1.26.11,<2.0.0", markers = "python_version >= \"3.6\""}
 
 [package.extras]
 aiohttp = ["aiohttp (>=3.5)"]
+arq = ["arq (>=0.23)"]
 beam = ["apache-beam (>=2.12)"]
 bottle = ["bottle (>=0.12.13)"]
 celery = ["celery (>=3)"]
@@ -1514,8 +1515,11 @@ chalice = ["chalice (>=1.16.0)"]
 django = ["django (>=1.8)"]
 falcon = ["falcon (>=1.4)"]
 fastapi = ["fastapi (>=0.79.0)"]
-flask = ["blinker (>=1.1)", "flask (>=0.11)"]
+flask = ["blinker (>=1.1)", "flask (>=0.11)", "markupsafe"]
+grpcio = ["grpcio (>=1.21.1)"]
 httpx = ["httpx (>=0.16.0)"]
+huey = ["huey (>=2)"]
+loguru = ["loguru (>=0.5)"]
 opentelemetry = ["opentelemetry-distro (>=0.35b0)"]
 pure-eval = ["asttokens", "executing", "pure-eval"]
 pymongo = ["pymongo (>=3.1)"]
@@ -1756,4 +1760,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "1e4e7378c3388e04e455e23a134b615e58c6672123351084290bff65fed449b9"
+content-hash = "87e1747ef15298ba1fd8a081acd9f500ea46822812a9e248deeec6fed76fe12c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ psycopg2-binary = "^2.9.5"
 jsonschema = "^4.17.3"
 
 [tool.poetry.group.dev.dependencies]
-bandit = "^1.7.4"
+bandit = {extras = ["toml"], version = "^1.7.4"}
 black = "^22.12.0"
 coverage = "^6.5.0"
 factory-boy = "^3.2.1"
@@ -39,6 +39,12 @@ mypy = "^1.2.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.bandit]
+# skips asserts
+# B101: https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html#
+# B104: https://bandit.readthedocs.io/en/latest/plugins/b104_hardcoded_bind_all_interfaces.html
+skips = ["B101", "B104"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ pydocstyle = "^6.3.0"
 pytest = "^7.2.0"
 pytest-django = "^4.5.2"
 pytest-cov = "^4.0.0"
-requests = "^2.28.1"
+requests = "^2.31.0"
 selenium = "^4.8.0"
 mypy = "^1.2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ django-stubs = "^1.13.1"
 dockerflow = "^2022.8.0"
 docutils = "^0.20"
 google-auth = {extras = ["pyopenssl"], version = "^2.15.0"}
-sentry-sdk = "^1.14.0"
+sentry-sdk = "^1.23.1"
 psycopg2-binary = "^2.9.5"
 jsonschema = "^4.17.3"
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2407](https://mozilla-hub.atlassian.net/browse/DISCO-2407)
GitHub: [#122 ](https://github.com/mozilla-services/consvc-shepherd/issues/122)

## Description
As part of verifying application stability and integrity, we want Shepherd to emit data to Sentry which we can monitor. 

Sentry boilerplate is in place, but there is no current project, associated DSN, environments or enabled logic in Shepherd.



Acceptance Criteria:

Sentry Project created

DSN Env variables deployed to cloudops-infra

Sentry config in Shepherd updated

Environment specific tagging in place (possibly)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [x] Functional and performance test coverage has been expanded and maintained (if applicable).

[DISCO-2407]: https://mozilla-hub.atlassian.net/browse/DISCO-2407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ