### PR TITLE
[DISCO-2421] fix: ignore blank forms when validating AllocationFormset

### DIFF
--- a/consvc_shepherd/forms.py
+++ b/consvc_shepherd/forms.py
@@ -99,10 +99,10 @@ class AllocationSettingFormset(BaseInlineFormSet):
         """Additional Form Validation."""
         super(AllocationSettingFormset, self).clean()
 
-        if sum((form.cleaned_data.get("percentage") for form in self.forms)) != 100:
+        if sum((form.cleaned_data.get("percentage", 0) for form in self.forms)) != 100:
             raise forms.ValidationError("Total Percentage has to add up to 100.")
 
-        partners = [form.cleaned_data.get("partner").name for form in self.forms]
+        partners = [form.cleaned_data.get("partner", "") for form in self.forms]
 
         if len(set(partners)) < len(partners):
             raise forms.ValidationError("A Partner is listed multiple times.")

--- a/consvc_shepherd/tests/test_forms.py
+++ b/consvc_shepherd/tests/test_forms.py
@@ -101,3 +101,15 @@ class TestAllocationFormSet(TestCase):
         self.assertEqual(
             form.non_form_errors(), ["A Partner is listed multiple times."]
         )
+
+    def test_returns_valid_with_one_blank_form_set(self):
+        """Test to ensure blank form is ignored when validating form data"""
+        extra_blank_form = {
+            "partner_allocations-2-id": "",
+            "partner_allocations-2-allocation_position": "",
+            "partner_allocations-2-partner": "",
+            "partner_allocations-2-percentage": "",
+        }
+        self.data.update(extra_blank_form)
+        form = AllocationFormset(data=self.data)
+        self.assertTrue(form.is_valid())


### PR DESCRIPTION
## References

JIRA: [DISCO-2421](https://mozilla-hub.atlassian.net/browse/DISCO-2421)

## Description
Currently, where there is a blank form for PartnerAllocation, Shepherd 500s since it takes its values as None and tries to use it to find the sum of percentages. This fixes so that a completely empty form is ignored. A partially completed form will cause validation errors from the model.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [X] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [X] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [X] Functional and performance test coverage has been expanded and maintained (if applicable).

[DISCO-2421]: https://mozilla-hub.atlassian.net/browse/DISCO-2421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ