### PR TITLE
[DISCO-2422] fix: Sort Advertiser by name in django admin

### DIFF
--- a/contile/admin.py
+++ b/contile/admin.py
@@ -30,6 +30,7 @@ class AdvertiserListAdmin(admin.ModelAdmin):
 
     model = Advertiser
     inlines = [AdUrlInline]
+    ordering = ("name",)
 
 
 @admin.register(Partner)


### PR DESCRIPTION
## References

JIRA: [DISCO-2422](https://mozilla-hub.atlassian.net/browse/DISCO-2422)

## Description
So we can have Advertisers listed by alphabetical order, which makes it easier to reference


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [X] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [X] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [X] Functional and performance test coverage has been expanded and maintained (if applicable).

[DISCO-2422]: https://mozilla-hub.atlassian.net/browse/DISCO-2422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ