### PR TITLE
Add Guardrails to require allocation to correspond to first two tiles

### DIFF
--- a/consvc_shepherd/tests/test_admin.py
+++ b/consvc_shepherd/tests/test_admin.py
@@ -232,26 +232,26 @@ class AllocationSettingAdminTest(TestCase):
         allocations: dict[str, Any] = {}
         allocations.update({"name": "SOV-20230101140000", "allocations": []})
 
-        adm_partner: Partner = Partner.objects.create(name="adm")
-        kevel_partner: Partner = Partner.objects.create(name="kevel")
+        amp_partner: Partner = Partner.objects.create(name="amp")
+        moz_partner: Partner = Partner.objects.create(name="moz_sales")
         position1_alloc: AllocationSetting = AllocationSetting.objects.create(
             position=1
         )
         PartnerAllocation.objects.create(
-            allocation_position=position1_alloc, partner=adm_partner, percentage=100
+            allocation_position=position1_alloc, partner=amp_partner, percentage=100
         )
         PartnerAllocation.objects.create(
-            allocation_position=position1_alloc, partner=kevel_partner, percentage=0
+            allocation_position=position1_alloc, partner=moz_partner, percentage=0
         )
 
         position2_alloc: AllocationSetting = AllocationSetting.objects.create(
             position=2
         )
         PartnerAllocation.objects.create(
-            allocation_position=position2_alloc, partner=adm_partner, percentage=85
+            allocation_position=position2_alloc, partner=amp_partner, percentage=85
         )
         PartnerAllocation.objects.create(
-            allocation_position=position2_alloc, partner=kevel_partner, percentage=15
+            allocation_position=position2_alloc, partner=moz_partner, percentage=15
         )
 
         mock_storage_open = mock.patch(

--- a/consvc_shepherd/tests/test_admin.py
+++ b/consvc_shepherd/tests/test_admin.py
@@ -9,7 +9,12 @@ from django.utils import timezone
 from jsonschema import validate
 from markus.testing import MetricsMock
 
-from consvc_shepherd.admin import ModelAdmin, publish_allocation, publish_snapshot, AllocationSettingAdmin
+from consvc_shepherd.admin import (
+    AllocationSettingAdmin,
+    ModelAdmin,
+    publish_allocation,
+    publish_snapshot,
+)
 from consvc_shepherd.models import (
     AllocationSetting,
     Partner,
@@ -266,7 +271,6 @@ class AllocationSettingAdminTest(TestCase):
         publish_allocation(None, request, AllocationSetting.objects.all())
         self.mock_storage_open.assert_called()
 
-
     def test_insufficient_positions_results_in_no_publish(self) -> None:
         """Test that publish action with insufficient allocation
         does not call send_to_storage.
@@ -274,7 +278,7 @@ class AllocationSettingAdminTest(TestCase):
         request = mock.Mock()
         publish_allocation(None, request, AllocationSetting.objects.filter(position=1))
         self.mock_storage_open.assert_not_called()
-    
+
     @override_settings(STATSD_ENABLED=True)
     def test_publish_allocation_metrics(self) -> None:
         """Test that publish action of allocation settings emits metrics."""
@@ -296,5 +300,3 @@ class AllocationSettingAdminTest(TestCase):
         allocation_setting_2 = AllocationSetting.objects.get(position=2)
         self.admin.delete_queryset(request, allocation_setting_2)
         self.assertEqual(AllocationSetting.objects.all().count(), 1)
-
-

--- a/consvc_shepherd/tests/test_admin.py
+++ b/consvc_shepherd/tests/test_admin.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from jsonschema import validate
 from markus.testing import MetricsMock
 
-from consvc_shepherd.admin import ModelAdmin, publish_allocation, publish_snapshot
+from consvc_shepherd.admin import ModelAdmin, publish_allocation, publish_snapshot, AllocationSettingAdmin
 from consvc_shepherd.models import (
     AllocationSetting,
     Partner,
@@ -45,10 +45,10 @@ class SettingsSnapshotAdminTest(TestCase):
             matching=True,
         )
         self.partner = Partner.objects.get(name="Partner1")
-        self.mock_storage_open = mock.patch(
+        mock_storage_open = mock.patch(
             "django.core.files.storage.default_storage." "open"
         )
-        self.mock_storage_open.start()
+        self.mock_storage_open = mock_storage_open.start()
         self.addCleanup(self.mock_storage_open.stop)
 
     def test_get_read_only_fields_when_obj_exists(self) -> None:
@@ -227,7 +227,7 @@ class AllocationSettingAdminTest(TestCase):
             self.allocation_schema = json.load(f)
 
         site = AdminSite()
-        self.admin = ModelAdmin(AllocationSetting, site)
+        self.admin = AllocationSettingAdmin(AllocationSetting, site)
 
         allocations: dict[str, Any] = {}
         allocations.update({"name": "SOV-20230101140000", "allocations": []})
@@ -238,42 +238,43 @@ class AllocationSettingAdminTest(TestCase):
             position=1
         )
         PartnerAllocation.objects.create(
-            allocation_position=position1_alloc, partner=adm_partner, percentage=85
+            allocation_position=position1_alloc, partner=adm_partner, percentage=100
         )
         PartnerAllocation.objects.create(
-            allocation_position=position1_alloc, partner=kevel_partner, percentage=15
+            allocation_position=position1_alloc, partner=kevel_partner, percentage=0
         )
+
         position2_alloc: AllocationSetting = AllocationSetting.objects.create(
             position=2
         )
         PartnerAllocation.objects.create(
-            allocation_position=position2_alloc, partner=adm_partner, percentage=90
+            allocation_position=position2_alloc, partner=adm_partner, percentage=85
         )
         PartnerAllocation.objects.create(
-            allocation_position=position2_alloc, partner=kevel_partner, percentage=10
+            allocation_position=position2_alloc, partner=kevel_partner, percentage=15
         )
-        self.mock_storage_open = mock.patch(
+
+        mock_storage_open = mock.patch(
             "django.core.files.storage.default_storage." "open"
         )
-        self.mock_storage_open.start()
+        self.mock_storage_open = mock_storage_open.start()
         self.addCleanup(self.mock_storage_open.stop)
 
     def test_publish_allocation(self) -> None:
-        """Test that publish action of allocation settings returns expected AllocationSetting."""
+        """Test that publish action of allocation settings calls send_to_storage."""
         request = mock.Mock()
-        expected: dict = {
-            "position": 1,
-            "allocation": [
-                {"partner": "adm", "percentage": 85},
-                {"partner": "kevel", "percentage": 15},
-            ],
-        }
-
         publish_allocation(None, request, AllocationSetting.objects.all())
+        self.mock_storage_open.assert_called()
 
-        allocation_setting: dict = AllocationSetting.objects.get(position=1).to_dict()
-        self.assertEqual(allocation_setting, expected)
 
+    def test_insufficient_positions_results_in_no_publish(self) -> None:
+        """Test that publish action with insufficient allocation
+        does not call send_to_storage.
+        """
+        request = mock.Mock()
+        publish_allocation(None, request, AllocationSetting.objects.filter(position=1))
+        self.mock_storage_open.assert_not_called()
+    
     @override_settings(STATSD_ENABLED=True)
     def test_publish_allocation_metrics(self) -> None:
         """Test that publish action of allocation settings emits metrics."""
@@ -295,3 +296,5 @@ class AllocationSettingAdminTest(TestCase):
         allocation_setting_2 = AllocationSetting.objects.get(position=2)
         self.admin.delete_queryset(request, allocation_setting_2)
         self.assertEqual(AllocationSetting.objects.all().count(), 1)
+
+

--- a/consvc_shepherd/tests/test_models.py
+++ b/consvc_shepherd/tests/test_models.py
@@ -9,24 +9,24 @@ class TestAllocationSettingModel(TestCase):
 
     def test_to_dict_produces_correctly(self) -> None:
         """Test for verifying to_dict() method for AllocationSetting"""
-        adm_partner: Partner = Partner.objects.create(name="adm")
-        kevel_partner: Partner = Partner.objects.create(name="kevel")
+        amp_partner: Partner = Partner.objects.create(name="amp")
+        moz_partner: Partner = Partner.objects.create(name="moz-sales")
         position1_alloc: AllocationSetting = AllocationSetting.objects.create(
             position=1
         )
 
         PartnerAllocation.objects.create(
-            allocation_position=position1_alloc, partner=adm_partner, percentage=85
+            allocation_position=position1_alloc, partner=amp_partner, percentage=85
         )
         PartnerAllocation.objects.create(
-            allocation_position=position1_alloc, partner=kevel_partner, percentage=15
+            allocation_position=position1_alloc, partner=moz_partner, percentage=15
         )
 
         expected_result: dict = {
             "position": 1,
             "allocation": [
-                {"partner": "adm", "percentage": 85},
-                {"partner": "kevel", "percentage": 15},
+                {"partner": "amp", "percentage": 85},
+                {"partner": "moz-sales", "percentage": 15},
             ],
         }
         self.assertEqual(position1_alloc.to_dict(), expected_result)
@@ -38,13 +38,13 @@ class TestPartnerAllocationModel(TestCase):
 
     def test_to_dict_produces_correctly(self) -> None:
         """Test for verifying to_dict() method for PartnerAllocation"""
-        adm_partner: Partner = Partner.objects.create(name="adm")
+        amp_partner: Partner = Partner.objects.create(name="amp")
         position1_alloc: AllocationSetting = AllocationSetting.objects.create(
             position=1
         )
         allocation1_adm: PartnerAllocation = PartnerAllocation.objects.create(
-            allocation_position=position1_alloc, partner=adm_partner, percentage=85
+            allocation_position=position1_alloc, partner=amp_partner, percentage=85
         )
         self.assertEqual(
-            allocation1_adm.to_dict(), {"partner": "adm", "percentage": 85}
+            allocation1_adm.to_dict(), {"partner": "amp", "percentage": 85}
         )

--- a/schema/allocation.schema.json
+++ b/schema/allocation.schema.json
@@ -15,7 +15,7 @@
             "type": "array",
             "description": "Allocations distributing partner percentages for each tile, left to right.",
             "uniqueItems": true,
-            "minItems": 1,
+            "minItems": 2,
             "items": {
                 "type": "object",
                 "properties": {
@@ -23,7 +23,7 @@
                         "type": "integer",
                         "description": "1-based position of tile from left side, 1 for the first slot.",
                         "minimum": 1,
-                        "maximum": 8
+                        "maximum": 2
                     },
                     "allocation": {
                         "type": "array",

--- a/schema/test_schema.py
+++ b/schema/test_schema.py
@@ -71,41 +71,31 @@ class TestJSONSchema(TestCase):
         with open("./schema/allocation.schema.json", "r") as f:
             allocations_schema = json.load(f)
             allocations: dict[str, Any] = {}
-            allocations.update(
-                {"name": "SOV-20230101140000", "allocations": []})
-            amp_partner: Partner = Partner.objects.create(
-                name="amp"
-            )
-            moz_partner: Partner = Partner.objects.create(
-                name="m0z-s@les"
-            )
+            allocations.update({"name": "SOV-20230101140000", "allocations": []})
+            amp_partner: Partner = Partner.objects.create(name="amp")
+            moz_partner: Partner = Partner.objects.create(name="m0z-s@les")
             position1_alloc: AllocationSetting = AllocationSetting.objects.create(
                 position=1
             )
 
             PartnerAllocation.objects.create(
-                allocation_position=position1_alloc,
-                partner=amp_partner,
-                percentage=85
+                allocation_position=position1_alloc, partner=amp_partner, percentage=85
             )
             PartnerAllocation.objects.create(
-                allocation_position=position1_alloc,
-                partner=moz_partner,
-                percentage=15
+                allocation_position=position1_alloc, partner=moz_partner, percentage=15
             )
 
             position2_alloc: AllocationSetting = AllocationSetting.objects.create(
                 position=2
             )
             PartnerAllocation.objects.create(
-                allocation_position=position2_alloc,
-                partner=amp_partner,
-                percentage=50
+                allocation_position=position2_alloc, partner=amp_partner, percentage=50
             )
             PartnerAllocation.objects.create(
-                allocation_position=position2_alloc,
-                partner=moz_partner,
-                percentage=50
+                allocation_position=position2_alloc, partner=moz_partner, percentage=50
             )
-            allocations["allocations"] = [position1_alloc.to_dict(), position2_alloc.to_dict()]
+            allocations["allocations"] = [
+                position1_alloc.to_dict(),
+                position2_alloc.to_dict(),
+            ]
             validate(allocations, allocations_schema)

--- a/schema/test_schema.py
+++ b/schema/test_schema.py
@@ -77,6 +77,7 @@ class TestJSONSchema(TestCase):
             position1_alloc: AllocationSetting = AllocationSetting.objects.create(
                 position=1
             )
+
             PartnerAllocation.objects.create(
                 allocation_position=position1_alloc, partner=adm_partner, percentage=85
             )
@@ -85,8 +86,6 @@ class TestJSONSchema(TestCase):
                 partner=kevel_partner,
                 percentage=15,
             )
-            allocations["allocations"].append(position1_alloc.to_dict())
-            validate(allocations, allocations_schema)
 
             position2_alloc: AllocationSetting = AllocationSetting.objects.create(
                 position=2
@@ -99,5 +98,5 @@ class TestJSONSchema(TestCase):
                 partner=kevel_partner,
                 percentage=50,
             )
-            allocations["allocations"].append(position2_alloc.to_dict())
+            allocations["allocations"] = [position1_alloc.to_dict(), position2_alloc.to_dict()]
             validate(allocations, allocations_schema)

--- a/schema/test_schema.py
+++ b/schema/test_schema.py
@@ -71,32 +71,41 @@ class TestJSONSchema(TestCase):
         with open("./schema/allocation.schema.json", "r") as f:
             allocations_schema = json.load(f)
             allocations: dict[str, Any] = {}
-            allocations.update({"name": "SOV-20230101140000", "allocations": []})
-            adm_partner: Partner = Partner.objects.create(name="adm")
-            kevel_partner: Partner = Partner.objects.create(name="k3-v-3l")
+            allocations.update(
+                {"name": "SOV-20230101140000", "allocations": []})
+            amp_partner: Partner = Partner.objects.create(
+                name="amp"
+            )
+            moz_partner: Partner = Partner.objects.create(
+                name="m0z-s@les"
+            )
             position1_alloc: AllocationSetting = AllocationSetting.objects.create(
                 position=1
             )
 
             PartnerAllocation.objects.create(
-                allocation_position=position1_alloc, partner=adm_partner, percentage=85
+                allocation_position=position1_alloc,
+                partner=amp_partner,
+                percentage=85
             )
             PartnerAllocation.objects.create(
                 allocation_position=position1_alloc,
-                partner=kevel_partner,
-                percentage=15,
+                partner=moz_partner,
+                percentage=15
             )
 
             position2_alloc: AllocationSetting = AllocationSetting.objects.create(
                 position=2
             )
             PartnerAllocation.objects.create(
-                allocation_position=position2_alloc, partner=adm_partner, percentage=50
+                allocation_position=position2_alloc,
+                partner=amp_partner,
+                percentage=50
             )
             PartnerAllocation.objects.create(
                 allocation_position=position2_alloc,
-                partner=kevel_partner,
-                percentage=50,
+                partner=moz_partner,
+                percentage=50
             )
             allocations["allocations"] = [position1_alloc.to_dict(), position2_alloc.to_dict()]
             validate(allocations, allocations_schema)


### PR DESCRIPTION
## References

JIRA: [DISCO-2425](https://mozilla-hub.atlassian.net/browse/DISCO-2425)

## Description
We want to add guardrails to ensure that AllocationSetting information is selected when publishing SOV



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [X] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [X] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [X] Functional and performance test coverage has been expanded and maintained (if applicable).

[DISCO-2425]: https://mozilla-hub.atlassian.net/browse/DISCO-2425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ