### PR TITLE
[DISCO-2423] Switch Country Select to only use smaller subset of countries

### DIFF
--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -43,7 +43,7 @@ STATSD_HOST = env("DJANGO_STATSD_HOST", default="127.0.0.1")
 STATSD_PORT = env("DJANGO_STATSD_PORT", default="8125")
 STATSD_PREFIX = env("DJANGO_STATSD_PREFIX", default="shepherd")
 
-# Settings for django-countries
+# Settings for django-countries. Contile AdvertiserUrl "geo" dropdown attribute.
 # See: https://pypi.org/project/django-countries/#customization
 # Contile advertisers list. Simply add the ISO 3166-1 country code to add as option.
 COUNTRIES_ONLY: list[str] = [

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -149,10 +149,8 @@ DEFAULT_AUTO_FIELD: str = "django.db.models.BigAutoField"
 
 DEFAULT_FILE_STORAGE: str = "storages.backends.gcloud.GoogleCloudStorage"
 GS_BUCKET_NAME = env("GS_BUCKET_NAME", default="")
-GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME",
-                          default="settings_from_shepherd")
-ALLOCATION_FILE_NAME: str = env(
-    "ALLOCATION_FILE_NAME", default="allocation_file")
+GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME", default="settings_from_shepherd")
+ALLOCATION_FILE_NAME: str = env("ALLOCATION_FILE_NAME", default="allocation_file")
 
 LOGGING: dict[str, Any] = {
     "version": 1,

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -43,6 +43,25 @@ STATSD_HOST = env("DJANGO_STATSD_HOST", default="127.0.0.1")
 STATSD_PORT = env("DJANGO_STATSD_PORT", default="8125")
 STATSD_PREFIX = env("DJANGO_STATSD_PREFIX", default="shepherd")
 
+# Settings for django-countries
+# See: https://pypi.org/project/django-countries/#customization
+# Contile advertisers list. Simply add the ISO 3166-1 country code to add as option.
+COUNTRIES_ONLY: list[str] = [
+    "AU",
+    "BR",
+    "CA",
+    "DE",
+    "ES",
+    "FR",
+    "GB",
+    "IN",
+    "IT",
+    "JP",
+    "MX",
+    "US",
+]
+COUNTRIES_FIRST_SORT: bool = True
+
 # Application definition
 
 INSTALLED_APPS: list[str] = [
@@ -130,8 +149,10 @@ DEFAULT_AUTO_FIELD: str = "django.db.models.BigAutoField"
 
 DEFAULT_FILE_STORAGE: str = "storages.backends.gcloud.GoogleCloudStorage"
 GS_BUCKET_NAME = env("GS_BUCKET_NAME", default="")
-GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME", default="settings_from_shepherd")
-ALLOCATION_FILE_NAME: str = env("ALLOCATION_FILE_NAME", default="allocation_file")
+GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME",
+                          default="settings_from_shepherd")
+ALLOCATION_FILE_NAME: str = env(
+    "ALLOCATION_FILE_NAME", default="allocation_file")
 
 LOGGING: dict[str, Any] = {
     "version": 1,

--- a/contile/models.py
+++ b/contile/models.py
@@ -121,6 +121,17 @@ class Advertiser(models.Model):
 class AdvertiserUrl(models.Model):
     """Class for AdvertiserUrl model.
 
+    Attributes
+    ----------
+    geo : django_countries.fields.CountryField
+        2-character ISO-3166-1 Country Code (str)
+    domain : CharField
+        Advertiser domain url
+    path : CharField
+        Advertiser path added to domain (requires '/' at minimum)
+    matching : BooleanField
+        boolean to trigger exact or prefix matching
+
     Methods
     -------
     __str__(self)


### PR DESCRIPTION
## References

JIRA: [DISCO-2423](https://mozilla-hub.atlassian.net/browse/DISCO-2423)
GitHub: [#138 ](https://github.com/mozilla-services/consvc-shepherd/issues/138)

## Description
Currently we have all the countries listed for Adops to select, this can cause some user error (ie selecting “United Kingdom” vs “United States”) as there’s too many to select from. It’s also annoying to scroll through all of them.

Upon doing some research, it appears that the [`django-countries`](https://github.com/SmileyChris/django-countries) library we use to generate the `CountryField` dropdown has configuration options that can be defined. No need for using db migrations and switching to `CharField`. In `settings.py`, the defined countries and a sorting flag are set. Therefore, we can easily add countries on the fly that won't require database migrations. This minimizes the risk of errors, the need for manual db migration changes and ensures simple, verifiable, ISO 3166-1 compliant country codes. 

Upon reviewing the set advertisers in production, the following were added:
`['AU', 'BR', 'CA', 'DE', 'ES', 'FR', 'GB', 'IN', 'IT', 'JP', 'MX', 'US']`

 If there is a master list of countries we support though adOps, I suggest we get it and add it so we can keep track in our service

See customization docs [here](https://pypi.org/project/django-countries/#customization)
![Screen Shot 2023-06-09 at 1 16 32 PM](https://github.com/mozilla-services/consvc-shepherd/assets/35045299/bebfb1e6-4961-47e3-9c94-b452dd646560)



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [x] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [ ] Functional and performance test coverage has been expanded and maintained (if applicable).

[DISCO-2423]: https://mozilla-hub.atlassian.net/browse/DISCO-2423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ