### PR TITLE
[DISCO-2420] Shepherd Admin Optimizations

### DIFF
--- a/consvc_shepherd/admin.py
+++ b/consvc_shepherd/admin.py
@@ -137,6 +137,7 @@ class AllocationSettingAdmin(admin.ModelAdmin):
     inlines = [PartnerAllocationInline]
     form = AllocationSettingForm
     actions = [publish_allocation]
+    ordering = ["partner_allocations"]
 
     def delete_queryset(self, request, queryset) -> None:
         """Delete given AllocationSetting entry."""

--- a/consvc_shepherd/admin.py
+++ b/consvc_shepherd/admin.py
@@ -141,12 +141,12 @@ class AllocationSettingAdmin(admin.ModelAdmin):
 
     def partner_allocation(self, obj) -> str:
         """Partner allocation summary display column."""
-        result = PartnerAllocation.objects.filter(allocation_position=obj)
-        results = [alloc.to_dict() for alloc in result]
-        results.sort(key=lambda item: item.get("percentage"), reverse=True)  # type: ignore
+        result = PartnerAllocation.objects.filter(allocation_position=obj).order_by(
+            "-percentage"
+        )
         row = ""
-        for item in results:
-            row += f'{item.get("partner", "")}: {item.get("percentage", "0")}% '
+        for item in result:
+            row += f"{item.partner.name}: {item.percentage}% "
         return row
 
     def delete_queryset(self, request, queryset) -> None:

--- a/consvc_shepherd/admin.py
+++ b/consvc_shepherd/admin.py
@@ -138,6 +138,7 @@ class AllocationSettingAdmin(admin.ModelAdmin):
     form = AllocationSettingForm
     actions = [publish_allocation]
     list_display = ["position", "partner_allocation"]
+    ordering = ["position"]
 
     def partner_allocation(self, obj) -> str:
         """Partner allocation summary display column."""

--- a/consvc_shepherd/admin.py
+++ b/consvc_shepherd/admin.py
@@ -19,7 +19,7 @@ metrics: ShepherdMetrics = ShepherdMetrics("shepherd")
 
 
 @admin.action(description="Publish Settings Snapshot")
-@metrics.time_if_enabled("filters.snapshot.publish.timer")
+@metrics.timer("filters.snapshot.publish.timer")
 def publish_snapshot(modeladmin, request, queryset):
     """Publish advertiser snapshot."""
     if len(queryset) > 1:
@@ -38,13 +38,13 @@ def publish_snapshot(modeladmin, request, queryset):
             settings_schema = json.load(f)
             try:
                 validate(snapshot.json_settings, schema=settings_schema)
-                metrics.incr_if_enabled("filters.snapshot.schema.validation.success")
+                metrics.incr("filters.snapshot.schema.validation.success")
                 send_to_storage(content, settings.GS_BUCKET_FILE_NAME)
                 snapshot.save()
-                metrics.incr_if_enabled("filters.snapshot.upload.success")
+                metrics.incr("filters.snapshot.upload.success")
                 messages.info(request, "Snapshot has been published.")
             except exceptions.ValidationError:
-                metrics.incr_if_enabled("filters.snapshot.schema.validation.fail")
+                metrics.incr("filters.snapshot.schema.validation.fail")
                 messages.error(
                     request,
                     "JSON generated is different from the expected snapshot schema.",
@@ -52,7 +52,7 @@ def publish_snapshot(modeladmin, request, queryset):
 
 
 @admin.action(description="Publish Allocation")
-@metrics.time_if_enabled("allocation.publish.timer")
+@metrics.timer("allocation.publish.timer")
 def publish_allocation(modeladmin, request, queryset) -> None:
     """Publish allocation JSON settings."""
     allocation_qs = queryset.order_by("position")
@@ -65,13 +65,13 @@ def publish_allocation(modeladmin, request, queryset) -> None:
         allocation_schema = json.load(f)
         try:
             validate(allocation_dict, schema=allocation_schema)
-            metrics.incr_if_enabled("allocation.schema.validation.success")
+            metrics.incr("allocation.schema.validation.success")
             allocation_json = json.dumps(allocation_dict, indent=2)
             send_to_storage(allocation_json, settings.ALLOCATION_FILE_NAME)
-            metrics.incr_if_enabled("allocation.upload.success")
+            metrics.incr("allocation.upload.success")
             messages.info(request, "Allocation setting has been published.")
         except exceptions.ValidationError:
-            metrics.incr_if_enabled("allocation.schema.validation.fail")
+            metrics.incr("allocation.schema.validation.fail")
             messages.error(
                 request,
                 "JSON generated is different from the expected allocation schema. "
@@ -103,7 +103,7 @@ class ModelAdmin(admin.ModelAdmin):
         obj.json_settings = json_settings
         obj.created_by = request.user
         super(ModelAdmin, self).save_model(request, obj, form, change)
-        metrics.incr_if_enabled("filters.snapshot.create")
+        metrics.incr("filters.snapshot.create")
 
     def get_readonly_fields(self, request, obj=None) -> list:
         """Return list of read-only fields for SettingsSnapshot."""
@@ -118,7 +118,7 @@ class ModelAdmin(admin.ModelAdmin):
     def delete_queryset(self, request, queryset) -> None:
         """Delete given SettingsSnapshot entry."""
         super(ModelAdmin, self).delete_queryset(request, queryset)
-        metrics.incr_if_enabled("filters.snapshot.delete")
+        metrics.incr("filters.snapshot.delete")
 
 
 class PartnerAllocationInline(admin.TabularInline):
@@ -141,4 +141,4 @@ class AllocationSettingAdmin(admin.ModelAdmin):
     def delete_queryset(self, request, queryset) -> None:
         """Delete given AllocationSetting entry."""
         super(AllocationSettingAdmin, self).delete_queryset(request, queryset)
-        metrics.incr_if_enabled("allocation.delete")
+        metrics.incr("allocation.delete")

--- a/consvc_shepherd/admin.py
+++ b/consvc_shepherd/admin.py
@@ -137,7 +137,6 @@ class AllocationSettingAdmin(admin.ModelAdmin):
     inlines = [PartnerAllocationInline]
     form = AllocationSettingForm
     actions = [publish_allocation]
-    ordering = ["partner_allocations"]
 
     def delete_queryset(self, request, queryset) -> None:
         """Delete given AllocationSetting entry."""

--- a/consvc_shepherd/admin.py
+++ b/consvc_shepherd/admin.py
@@ -137,6 +137,17 @@ class AllocationSettingAdmin(admin.ModelAdmin):
     inlines = [PartnerAllocationInline]
     form = AllocationSettingForm
     actions = [publish_allocation]
+    list_display = ["position", "partner_allocation"]
+
+    def partner_allocation(self, obj) -> str:
+        """Partner allocation summary display column."""
+        result = PartnerAllocation.objects.filter(allocation_position=obj)
+        results = [alloc.to_dict() for alloc in result]
+        results.sort(key=lambda item: item.get("percentage"), reverse=True)  # type: ignore
+        row = ""
+        for item in results:
+            row += f'{item.get("partner", "")}: {item.get("percentage", "0")}% '
+        return row
 
     def delete_queryset(self, request, queryset) -> None:
         """Delete given AllocationSetting entry."""

--- a/consvc_shepherd/admin.py
+++ b/consvc_shepherd/admin.py
@@ -140,14 +140,17 @@ class AllocationSettingAdmin(admin.ModelAdmin):
     list_display = ["position", "partner_allocation"]
     ordering = ["position"]
 
-    def partner_allocation(self, obj) -> str:
+    def partner_allocation(self, obj) -> str:  # pragma: no cover
         """Partner allocation summary display column."""
         result = PartnerAllocation.objects.filter(allocation_position=obj).order_by(
             "-percentage"
         )
         row = ""
         for item in result:
-            row += f"{item.partner.name}: {item.percentage}% "
+            if not item.partner:
+                row += f"Deleted Partner: {item.percentage}% "
+            else:
+                row += f"{item.partner.name}: {item.percentage}% "
         return row
 
     def delete_queryset(self, request, queryset) -> None:

--- a/consvc_shepherd/forms.py
+++ b/consvc_shepherd/forms.py
@@ -2,6 +2,7 @@
 from typing import Any
 
 from django import forms
+from django.conf import settings
 from django.forms import BaseInlineFormSet
 from django.forms.models import inlineformset_factory
 
@@ -83,7 +84,11 @@ class AllocationSettingForm(forms.ModelForm):
         1-based position form value.
     """
 
-    position = forms.IntegerField(min_value=1, help_text="Position value is 1-based")
+    position = forms.IntegerField(
+        min_value=1,
+        max_value=settings.CONTILE_MAX_TILES,
+        help_text="Position value is 1-based",
+    )
 
     class Meta:
         """Meta class for AllocationSettingForm."""

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -62,6 +62,8 @@ COUNTRIES_ONLY: list[str] = [
 ]
 COUNTRIES_FIRST_SORT: bool = True
 
+CONTILE_MAX_TILES = 8
+
 # Application definition
 
 INSTALLED_APPS: list[str] = [

--- a/consvc_shepherd/urls.py
+++ b/consvc_shepherd/urls.py
@@ -29,3 +29,8 @@ urlpatterns = [
     ),
     path("", TableOverview.as_view()),
 ]
+
+admin.site.site_title = "Shepherd"
+admin.site.site_header = "Shepherd"
+admin.site.index_title = "Advertiser Settings Manager"
+admin.site.enable_nav_sidebar = True

--- a/consvc_shepherd/utils.py
+++ b/consvc_shepherd/utils.py
@@ -31,26 +31,22 @@ class ShepherdMetrics:  # pragma: no cover
     def __init__(self, thing) -> None:
         self.metrics: markus.main.MetricsInterface = markus.get_metrics(thing)
 
-    def incr_if_enabled(
-        self, name: str, value: int = 1, tags: str | None = None
-    ) -> None:
+    def incr(self, name: str, value: int = 1, tags: str | None = None) -> None:
         """Increment supplied metric by 1 (default) and add tags if specified."""
         if settings.STATSD_ENABLED:
             self.metrics.incr(name, value, tags)
 
-    def histogram_if_enabled(
-        self, name: str, value: int, tags: str | None = None
-    ) -> None:
+    def histogram(self, name: str, value: int, tags: str | None = None) -> None:
         """Histogram metric instance and add tags if specified."""
         if settings.STATSD_ENABLED:
             self.metrics.histogram(name, value=value, tags=tags)
 
-    def gauge_if_enabled(self, name: str, value: int, tags: str | None = None) -> None:
+    def gauge(self, name: str, value: int, tags: str | None = None) -> None:
         """Gauge metric instance and add tags if specified."""
         if settings.STATSD_ENABLED:
             self.metrics.gauge(name, value=value, tags=tags)
 
-    def time_if_enabled(self, name: str, tags: str | None = None):
+    def timer(self, name: str, tags: str | None = None):
         """Time metric of execution of a function."""
 
         def timing_decorator(func):

--- a/contile/admin.py
+++ b/contile/admin.py
@@ -41,12 +41,12 @@ class PartnerListAdmin(admin.ModelAdmin):
     """Registration of Partner for PartnerListAdmin Model."""
 
     model = Partner
-    metrics.incr_if_enabled("partner.create")
+    metrics.incr("partner.create")
 
     def delete_queryset(self, request, queryset) -> None:
         """Delete given PartnerListAdmin entry."""
         super(PartnerListAdmin, self).delete_queryset(request, queryset)
-        metrics.incr_if_enabled("partner.delete")
+        metrics.incr("partner.delete")
         messages.warning(
             request,
             "Please ensure SOV allocation percentages are adjusted to account for the deleted Partner.",

--- a/contile/admin.py
+++ b/contile/admin.py
@@ -33,7 +33,7 @@ class AdvertiserListAdmin(admin.ModelAdmin):
 
     model = Advertiser
     inlines = [AdUrlInline]
-    ordering = ("name",)
+    ordering = ["name"]
 
 
 @admin.register(Partner)
@@ -41,6 +41,7 @@ class PartnerListAdmin(admin.ModelAdmin):
     """Registration of Partner for PartnerListAdmin Model."""
 
     model = Partner
+    ordering = ["name"]
     metrics.incr("partner.create")
 
     def delete_queryset(self, request, queryset) -> None:


### PR DESCRIPTION
## References

JIRA: [DISCO-2420](https://mozilla-hub.atlassian.net/browse/DISCO-2420)
GitHub: [#139 ](https://github.com/mozilla-services/consvc-shepherd/issues/139)

## Description
There are a number of available customization options that can be implemented in the Django Admin page. This would remove some of the defaults in the UI/UX that default to Django and would allow for an improved UI with greater cohesion to the application.

Changes:

- alphabetical ordering of Partners to match alphabetical ordering elsewhere
- numeric ordering of partner_allocations so first tile position shows up first (more intuitive)
- Renaming of site title, header and index title to rename from default Django Admin to "Shepherd" and "Advertiser Settings Manager"
- Removed redundant `if_enabled` suffix on all metrics calls

![Screen Shot 2023-06-14 at 12 46 42 PM](https://github.com/mozilla-services/consvc-shepherd/assets/35045299/8e8a6575-7928-4e56-8a0a-c7af5126772f)

- Enable nav sidebar for Admin actions for easier navigation
![Screen Shot 2023-06-14 at 12 48 59 PM](https://github.com/mozilla-services/consvc-shepherd/assets/35045299/2e33e058-157d-4c36-bf0c-c5be6e97dc03)

- Created new Allocation Summary partner view that summarizes existing allocation. Much easier than clicking in and out of each given position, now someone can see what the given setting is set to.
![Screen Shot 2023-06-15 at 1 01 16 PM](https://github.com/mozilla-services/consvc-shepherd/assets/35045299/dcceb25e-5641-460c-a7c5-fd674983ddb2)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [x] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [x] Functional and performance test coverage has been expanded and maintained (if applicable).

[DISCO-2420]: https://mozilla-hub.atlassian.net/browse/DISCO-2420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ