### PR TITLE
[DISCO-2447] chore: Disable Sentry transcations for Shepherd

### DIFF
--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -182,7 +182,7 @@ LOGGING: dict[str, Any] = {
 SENTRY_DSN = env("SENTRY_DSN", default=None)
 # Any of "release", "debug", or "disabled". Using "debug" will enable logging for Sentry.
 SENTRY_MODE = env("SENTRY_DEBUG_MODE", default="disabled")
-SENTRY_TRACE_SAMPLE_RATE = env("SENTRY_TRACE_SAMPLE_RATE", default=1.0)
+SENTRY_TRACE_SAMPLE_RATE = env("SENTRY_TRACE_SAMPLE_RATE", default=0)
 SENTRY_ENV = env("SENTRY_ENV", default=None)
 
 sentry_sdk.init(
@@ -200,7 +200,7 @@ sentry_sdk.init(
     release=fetch_app_version_from_file().commit,
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for performance monitoring.
-    # We recommend adjusting this value in production,
+    # Disabled by default as not utilized currently. Extra cost.
     traces_sample_rate=SENTRY_TRACE_SAMPLE_RATE,
 )
 


### PR DESCRIPTION
## References

JIRA: [DISCO-2447](https://mozilla-hub.atlassian.net/browse/DISCO-2447)
GitHub: [#144 ](https://github.com/mozilla-services/consvc-shepherd/issues/144)

## Description
Sentry sent an email indicating this feature is out of beta and will become a subscription service. We don’t find this super useful for Merino and won’t need it for Shepherd, so  disabling it.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [x] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [ ] Functional and performance test coverage has been expanded and maintained (if applicable).

[DISCO-2447]: https://mozilla-hub.atlassian.net/browse/DISCO-2447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ