### PR TITLE
[DISCO-2458] feat: Display latest launched allocation snapshot on List Page

### DIFF
--- a/consvc_shepherd/models.py
+++ b/consvc_shepherd/models.py
@@ -1,4 +1,5 @@
 """Models module for consvc_shepherd."""
+import json
 from typing import Any
 
 from django.contrib.auth import get_user_model
@@ -111,6 +112,14 @@ class AllocationSettingsSnapshot(models.Model):
         null=True,
     )
     launched_date: DateTimeField = models.DateTimeField(blank=True, null=True)
+
+    @property
+    def json_settings_formatted(self):
+        """Pretty print json_settings."""
+        return json.dumps(self.json_settings, indent=2)
+
+    def __str__(self):
+        return f"{self.name} - {self.created_on.strftime('%Y-%m-%d %H:%M')}"
 
 
 class AllocationSetting(models.Model):

--- a/consvc_shepherd/views.py
+++ b/consvc_shepherd/views.py
@@ -5,7 +5,11 @@ from django.shortcuts import render
 from django.views.generic import ListView, TemplateView
 
 from consvc_shepherd.forms import SnapshotCompareForm
-from consvc_shepherd.models import AllocationSetting, SettingsSnapshot
+from consvc_shepherd.models import (
+    AllocationSetting,
+    AllocationSettingsSnapshot,
+    SettingsSnapshot,
+)
 
 
 class TableOverview(TemplateView):
@@ -69,5 +73,10 @@ class AllocationSettingList(ListView):
         context = super().get_context_data(**kwargs)
         context["allocation_settings"] = AllocationSetting.objects.all().order_by(
             "position"
+        )
+        context["latest_snapshot"] = (
+            AllocationSettingsSnapshot.objects.filter(launched_date__isnull=False)
+            .order_by("-created_on")
+            .first()
         )
         return context

--- a/templates/allocation/allocation_list.html
+++ b/templates/allocation/allocation_list.html
@@ -4,17 +4,30 @@
 {% block content %}
     <div class="p-5 w-75 mx-auto">
         <h2>Allocation Settings</h2>
-        <a class="mb-4" href="/admin/consvc_shepherd/allocationsetting/add/">Add New Position</a>
+        <div class="d-flex justify-content-between mb-2">
+            <span>Latest Snapshot:
+            <button class="btn btn-link" data-bs-toggle="collapse" href="#snapshot">
+            {{ latest_snapshot }}
+        </button>
+        </span>
+        <a class="btn btn-primary" href="/admin/consvc_shepherd/allocationsettingssnapshot/add/">Create Snapshot</a>
+        </div>
+        <div id="snapshot" class="collapse">
+            <pre class="bg-dark text-light p-2">{{ latest_snapshot.json_settings_formatted }}
+        </pre>
+        </div>
+
+        <a class="mb-2" href="/admin/consvc_shepherd/allocationsetting/add/">Add New Position</a>
         {% for a_s in allocation_settings %}
-            <div class="card p-2 mt-4 ">
+            <div class="card p-2 mb-4 ">
                 <div class="px-2 d-flex justify-content-between align-items-center">
                     <h4> Position {{ a_s.position }}</h4>
                     <a href="/admin/consvc_shepherd/allocationsetting/{{ a_s.id }}/change/">edit</a>
                 </div>
                 <table class="table ">
                     <thead class="text-secondary">
-                        <th>Partner</th>
-                        <th>Percentage (%)</th>
+                    <th>Partner</th>
+                    <th>Percentage (%)</th>
                     </thead>
                     <tbody>
                     {% for p_a in a_s.partner_allocations.all %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.4/font/bootstrap-icons.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <title>Shepherd</title>
 </head>
 <body class="bg-light">


### PR DESCRIPTION
## References

JIRA: [DISCO-2458](https://mozilla-hub.atlassian.net/browse/DISCO-2458)

## Description
A small step to shuffle things away from django admin
![Screenshot 2023-06-21 at 7 12 38 PM](https://github.com/mozilla-services/consvc-shepherd/assets/25379936/b2267930-79b6-4307-a117-778ef4764043)



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [X] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [X] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [ ] Functional and performance test coverage has been expanded and maintained (if applicable).

[DISCO-2458]: https://mozilla-hub.atlassian.net/browse/DISCO-2458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ