### PR TITLE
feat: allocationsettings ui

### DIFF
--- a/consvc_shepherd/tests/test_forms.py
+++ b/consvc_shepherd/tests/test_forms.py
@@ -1,8 +1,16 @@
 """Forms test module for consvc_shepherd."""
 from django.test import TestCase
 
-from consvc_shepherd.forms import AllocationFormset, SnapshotCompareForm
-from consvc_shepherd.models import SettingsSnapshot
+from consvc_shepherd.forms import (
+    AllocationFormset,
+    AllocationSettingsSnapshotForm,
+    SnapshotCompareForm,
+)
+from consvc_shepherd.models import (
+    AllocationSetting,
+    PartnerAllocation,
+    SettingsSnapshot,
+)
 from contile.models import Partner
 
 
@@ -112,4 +120,35 @@ class TestAllocationFormSet(TestCase):
         }
         self.data.update(extra_blank_form)
         form = AllocationFormset(data=self.data)
+        self.assertTrue(form.is_valid())
+
+
+class TestAllocationSettingsSnapshotForm(TestCase):
+    """Test Allocation Snapshot Form."""
+
+    def test_form_raises_error_with_invalid_json(self):
+        """Test that validation error occurs when missing a required field."""
+        Partner.objects.create(name="amp")
+        AllocationSetting.objects.create(position=1)
+        data = {
+            "name": "Snapshot 1",
+        }
+        form = AllocationSettingsSnapshotForm(data=data)
+        self.assertFalse(form.is_valid())
+
+    def test_form_returns_true_when_valid(self):
+        """Test that validation error occurs when missing a required field."""
+        partner = Partner.objects.create(name="amp")
+        alloc_setting_1 = AllocationSetting.objects.create(position=1)
+        alloc_setting_2 = AllocationSetting.objects.create(position=2)
+        PartnerAllocation.objects.create(
+            allocation_position=alloc_setting_1, partner=partner, percentage=100
+        )
+        PartnerAllocation.objects.create(
+            allocation_position=alloc_setting_2, partner=partner, percentage=100
+        )
+        data = {
+            "name": "Snapshot 1",
+        }
+        form = AllocationSettingsSnapshotForm(data=data)
         self.assertTrue(form.is_valid())

--- a/schema/allocation.schema.json
+++ b/schema/allocation.schema.json
@@ -27,6 +27,7 @@
                     },
                     "allocation": {
                         "type": "array",
+                        "minItems": 1,
                         "uniqueItems": true,
                         "items": {
                             "type": "object",

--- a/templates/allocation/allocation_list.html
+++ b/templates/allocation/allocation_list.html
@@ -4,13 +4,18 @@
 {% block content %}
     <div class="p-5 w-75 mx-auto">
         <h2>Allocation Settings</h2>
+        {% if errors %}
+            <div class="alert alert-danger">{{ errors }}</div>
+        {% endif %}
         <div class="d-flex justify-content-between mb-2">
             <span>Latest Snapshot:
             <button class="btn btn-link" data-bs-toggle="collapse" href="#snapshot">
             {{ latest_snapshot }}
         </button>
         </span>
-        <a class="btn btn-primary" href="/admin/consvc_shepherd/allocationsettingssnapshot/add/">Create Snapshot</a>
+            <button class="btn btn-primary" type="button" data-bs-toggle="modal" data-bs-target="#snapshotModal">Create
+                Snapshot
+            </button>
         </div>
         <div id="snapshot" class="collapse">
             <pre class="bg-dark text-light p-2">{{ latest_snapshot.json_settings_formatted }}
@@ -45,5 +50,29 @@
         {% empty %}
             <h5>No allocations set.</h5>
         {% endfor %}
+        <div class="modal fade" id="snapshotModal" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h1 class="modal-title fs-5" id="ModalLabel">Create Snapshot</h1>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <form action="" method="post">
+                        <div class="modal-body">
+
+                            {% csrf_token %}
+                            {{ form.name.label }}
+                            {{ form.name }}
+
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                            <button type="Submit" class="btn btn-primary">Create</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
     </div>
 {% endblock content %}


### PR DESCRIPTION
## References

![Screenshot 2023-06-28 at 9 44 52 PM](https://github.com/mozilla-services/consvc-shepherd/assets/25379936/b05c1adb-28cf-436a-ba9e-bbcc902ce640)


## Description
Moving publishing allocation snapshot away from django admin. eliminates two step publishing, which i think is okay, since the number of allocations is small



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [ ] Functional and performance test coverage has been expanded and maintained (if applicable).