### PR TITLE
[DISCO-2494] fix: use correct file name when sending alloc to GCS

### DIFF
--- a/consvc_shepherd/views.py
+++ b/consvc_shepherd/views.py
@@ -113,7 +113,7 @@ class AllocationSettingList(ListView):
 
             send_to_storage(
                 json.dumps(instance.json_settings, indent=2),
-                settings.GS_BUCKET_FILE_NAME,
+                settings.ALLOCATION_FILE_NAME,
             )
             metrics.incr("allocation.upload.success")
             context["latest_snapshot"] = instance


### PR DESCRIPTION
## References

JIRA: [DISCO-2494](https://mozilla-hub.atlassian.net/browse/DISCO-2494)
GitHub: [#155](https://github.com/mozilla-services/consvc-shepherd/issues/155)

## Description
custom ui currently uses the wrong file name when sending settings to the GCS bucket. As a result it overwrites the adm settings file, which we don’t want.



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [X] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [X] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [ ] Functional and performance test coverage has been expanded and maintained (if applicable).

[DISCO-2494]: https://mozilla-hub.atlassian.net/browse/DISCO-2494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ