### PR TITLE
[DISCO-2545] feat: Allow 3 sov allocations in schema

### DIFF
--- a/schema/allocation.schema.json
+++ b/schema/allocation.schema.json
@@ -23,7 +23,7 @@
                         "type": "integer",
                         "description": "1-based position of tile from left side, 1 for the first slot.",
                         "minimum": 1,
-                        "maximum": 2
+                        "maximum": 3
                     },
                     "allocation": {
                         "type": "array",

--- a/schema/test_schema.py
+++ b/schema/test_schema.py
@@ -4,7 +4,7 @@ from typing import Any
 from unittest import TestCase
 
 import pytest
-from jsonschema import validate
+from jsonschema import exceptions, validate
 
 from consvc_shepherd.models import AllocationSetting, PartnerAllocation
 from contile.models import Advertiser, AdvertiserUrl, Partner
@@ -13,6 +13,39 @@ from contile.models import Advertiser, AdvertiserUrl, Partner
 @pytest.mark.django_db
 class TestJSONSchema(TestCase):
     """Test JSON schemas that Shepherd produces."""
+
+    def setUp(self) -> None:
+        """Set up test data"""
+        self.amp_partner: Partner = Partner.objects.create(name="amp")
+        self.moz_partner: Partner = Partner.objects.create(name="m0z-s@les")
+        self.position1_alloc: AllocationSetting = AllocationSetting.objects.create(
+            position=1
+        )
+
+        PartnerAllocation.objects.create(
+            allocation_position=self.position1_alloc,
+            partner=self.amp_partner,
+            percentage=85,
+        )
+        PartnerAllocation.objects.create(
+            allocation_position=self.position1_alloc,
+            partner=self.moz_partner,
+            percentage=15,
+        )
+
+        self.position2_alloc: AllocationSetting = AllocationSetting.objects.create(
+            position=2
+        )
+        PartnerAllocation.objects.create(
+            allocation_position=self.position2_alloc,
+            partner=self.amp_partner,
+            percentage=50,
+        )
+        PartnerAllocation.objects.create(
+            allocation_position=self.position2_alloc,
+            partner=self.moz_partner,
+            percentage=50,
+        )
 
     def test_filter_schema(self) -> None:
         """Tests filter schema for adM."""
@@ -72,30 +105,54 @@ class TestJSONSchema(TestCase):
             allocations_schema = json.load(f)
             allocations: dict[str, Any] = {}
             allocations.update({"name": "SOV-20230101140000", "allocations": []})
-            amp_partner: Partner = Partner.objects.create(name="amp")
-            moz_partner: Partner = Partner.objects.create(name="m0z-s@les")
-            position1_alloc: AllocationSetting = AllocationSetting.objects.create(
-                position=1
-            )
 
-            PartnerAllocation.objects.create(
-                allocation_position=position1_alloc, partner=amp_partner, percentage=85
-            )
-            PartnerAllocation.objects.create(
-                allocation_position=position1_alloc, partner=moz_partner, percentage=15
-            )
-
-            position2_alloc: AllocationSetting = AllocationSetting.objects.create(
-                position=2
-            )
-            PartnerAllocation.objects.create(
-                allocation_position=position2_alloc, partner=amp_partner, percentage=50
-            )
-            PartnerAllocation.objects.create(
-                allocation_position=position2_alloc, partner=moz_partner, percentage=50
-            )
             allocations["allocations"] = [
-                position1_alloc.to_dict(),
-                position2_alloc.to_dict(),
+                self.position1_alloc.to_dict(),
+                self.position2_alloc.to_dict(),
             ]
             validate(allocations, allocations_schema)
+
+    def test_too_many_allocation_raises_errors(self) -> None:
+        """Tests partner allocation schema for SOV (Share of Voice) raise error with invalid."""
+        with open("./schema/allocation.schema.json", "r") as f:
+            allocations_schema = json.load(f)
+            allocations: dict[str, Any] = {}
+            allocations.update({"name": "SOV-20230101140000", "allocations": []})
+            position3_alloc: AllocationSetting = AllocationSetting.objects.create(
+                position=3
+            )
+
+            PartnerAllocation.objects.create(
+                allocation_position=position3_alloc,
+                partner=self.amp_partner,
+                percentage=22,
+            )
+            PartnerAllocation.objects.create(
+                allocation_position=position3_alloc,
+                partner=self.moz_partner,
+                percentage=78,
+            )
+
+            position4_alloc: AllocationSetting = AllocationSetting.objects.create(
+                position=4
+            )
+            PartnerAllocation.objects.create(
+                allocation_position=position4_alloc,
+                partner=self.amp_partner,
+                percentage=25,
+            )
+            PartnerAllocation.objects.create(
+                allocation_position=position4_alloc,
+                partner=self.moz_partner,
+                percentage=75,
+            )
+
+            allocations["allocations"] = [
+                self.position1_alloc.to_dict(),
+                self.position2_alloc.to_dict(),
+                position3_alloc.to_dict(),
+                position4_alloc.to_dict(),
+            ]
+            with self.assertRaises(exceptions.ValidationError) as context:
+                validate(allocations, allocations_schema)
+            self.assertIn("4 is greater than the maximum of 3", str(context.exception))


### PR DESCRIPTION
## References

JIRA: [DISCO-2545](https://mozilla-hub.atlassian.net/browse/DISCO-2545)
GitHub: [#163](https://github.com/mozilla-services/consvc-shepherd/issues/163)

## Description
We will eventually want to have SOV for the third tile, this allows the schema to be less strict about allocations.
I don't think this should affect the existing behaviour of two allocations either



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [ ] Functional and performance test coverage has been expanded and maintained (if applicable).

[DISCO-2545]: https://mozilla-hub.atlassian.net/browse/DISCO-2545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ