### PR TITLE
[DISCO-2574] Ability to run tests using docker workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,3 +73,7 @@ doc-preview: doc  ##  Preview Merino docs via the default browser
 .PHONY: dev
 dev: $(INSTALL_STAMP)  ##  Run shepherd locally and reload automatically
 	$(POETRY) run python manage.py runserver
+
+.PHONY: local_test
+local_test: $(INSTALL_STAMP)
+	docker-compose -f docker-compose.test.yml up --abort-on-container-exit

--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,8 @@ doc-preview: doc  ##  Preview Merino docs via the default browser
 
 .PHONY: dev
 dev: $(INSTALL_STAMP)  ##  Run shepherd locally and reload automatically
-	$(POETRY) run python manage.py runserver
+	docker-compose up
 
-.PHONY: local_test
-local_test: $(INSTALL_STAMP)
+.PHONY: local-test
+local-test: $(INSTALL_STAMP)
 	docker-compose -f docker-compose.test.yml up --abort-on-container-exit

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,36 @@
+version: "3"
+
+services:
+  db:
+    tty: true
+    restart: always
+    image: postgres:14.0
+    volumes:
+      - db_volume:/var/lib/postgresql/
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - "5432:5432"
+
+  app:
+    tty: true
+    env_file:
+      - .env
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+    command: bash -c "/app/bin/wait-for-it.sh db:5432 -- pip install poetry && poetry install && poetry run pytest --cov --cov-report=term-missing --cov-fail-under=95 "
+    links:
+      - db
+
+    volumes:
+      - .:/app
+    ports:
+      - "7001:7001"
+    depends_on:
+      - db
+
+volumes:
+  db_volume:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
     command: bash -c "/app/bin/wait-for-it.sh db:5432 -- python /app/manage.py migrate && python /app/manage.py runserver 0.0.0.0:7001 "
     links:
       - db
-
     volumes:
       - .:/app
     ports:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,7 +13,7 @@ Unit tests are written and executed with `pytest` and are located in the test di
 
 ## Local Test Execution
 
-To execute unit tests in the local Docker container, run: `make local_test`.
+To execute unit tests in the local Docker container, run: `make local-test`.
 
 ## Note on CI Test Execution
 By default, unit tests run automatically in CI during each push to an active PR and during the merge process. 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,7 +13,7 @@ Unit tests are written and executed with `pytest` and are located in the test di
 
 ## Local Test Execution
 
-To execute unit tests locally, run: `make test`.
+To execute unit tests locally, run: `make local_test`.
 
 ## Note on CI Test Execution
 By default, unit tests run automatically in CI during each push to an active PR and during the merge process. 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,7 +13,7 @@ Unit tests are written and executed with `pytest` and are located in the test di
 
 ## Local Test Execution
 
-To execute unit tests locally, run: `make local_test`.
+To execute unit tests in the local Docker container, run: `make local_test`.
 
 ## Note on CI Test Execution
 By default, unit tests run automatically in CI during each push to an active PR and during the merge process. 


### PR DESCRIPTION
## References

JIRA: [DISCO-2574](https://mozilla-hub.atlassian.net/browse/DISCO-2574)

## Description
Because we switch to a docker workflow, the existing `make test` does not work



## PR Review Checklist

_Put an `x` in the boxes that apply_

- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [ ] Functional and performance test coverage has been expanded and maintained (if applicable).

[DISCO-2574]: https://mozilla-hub.atlassian.net/browse/DISCO-2574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ