### PR TITLE
[AE-388] Tweaks to the preview page

### DIFF
--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -1,4 +1,5 @@
 """Ads Preview page"""
+
 import uuid
 from dataclasses import dataclass
 from typing import TypedDict
@@ -215,7 +216,9 @@ def get_tiles(env: Environment, country: str, region: str) -> list[Tile]:
         "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:126.0) Gecko/20100101 Firefox/126.0",
     }
 
-    r = requests.get(f"{env.mars_url}/v1/tiles", params=params, headers=headers, timeout=30)
+    r = requests.get(
+        f"{env.mars_url}/v1/tiles", params=params, headers=headers, timeout=30
+    )
 
     return [
         Tile(
@@ -238,6 +241,7 @@ def localized_sponsored_by(spoc: dict[str, str], country: str) -> str:
 
 
 def find_env_by_code(env_code: str) -> Environment:
+    """Find an environment by code, raise an exception if no environment is found"""
     for env in ENVIRONMENTS:
         if env.code == env_code:
             return env

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -45,7 +45,7 @@ class Region(TypedDict):
 
 @dataclass(frozen=True)
 class Environment:
-    """Represents a Site in Kevel. Some environments have more than one site configured."""
+    """Represents an Ads environment, not to be confused with a MARS or Shepherd environment."""
 
     code: str
     name: str

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -188,8 +188,6 @@ SENTRY_MODE = env("SENTRY_MODE", default="disabled")
 SENTRY_TRACE_SAMPLE_RATE = env("SENTRY_TRACE_SAMPLE_RATE", default=0)
 SENTRY_ENV = env("SENTRY_ENV", default=None)
 
-MARS_URL = env("MARS_URL", default="https://mars.prod.ads.prod.webservices.mozgcp.net")
-
 sentry_sdk.init(
     dsn=SENTRY_DSN,
     integrations=[

--- a/consvc_shepherd/static/preview/css/preview.css
+++ b/consvc_shepherd/static/preview/css/preview.css
@@ -26,9 +26,16 @@
 
 .tiles, .spocs {
     display: flex;
-    column-gap: 24px;
-    row-gap: 24px;
     flex-wrap: wrap;
+    row-gap: 24px;
+}
+
+.tiles {
+    column-gap: 32px;
+}
+
+.spocs {
+    column-gap: 24px;
 }
 
 .tile {
@@ -53,6 +60,7 @@
 }
 
 .tile-title {
+    width: 88px;
     padding-top: 8px;
     text-align: center;
     line-height: normal;

--- a/consvc_shepherd/static/preview/css/preview.css
+++ b/consvc_shepherd/static/preview/css/preview.css
@@ -20,8 +20,8 @@
     font-weight: bold;
 }
 
-#region-container {
-    margin-left: 20px;
+#preview select {
+    margin-right: 20px;
 }
 
 .tiles, .spocs {

--- a/static/preview/css/preview.css
+++ b/static/preview/css/preview.css
@@ -26,9 +26,16 @@
 
 .tiles, .spocs {
     display: flex;
-    column-gap: 24px;
-    row-gap: 24px;
     flex-wrap: wrap;
+    row-gap: 24px;
+}
+
+.tiles {
+    column-gap: 32px;
+}
+
+.spocs {
+    column-gap: 24px;
 }
 
 .tile {
@@ -53,6 +60,7 @@
 }
 
 .tile-title {
+    width: 88px;
     padding-top: 8px;
     text-align: center;
     line-height: normal;

--- a/static/preview/css/preview.css
+++ b/static/preview/css/preview.css
@@ -20,8 +20,8 @@
     font-weight: bold;
 }
 
-#region-container {
-    margin-left: 20px;
+#preview select {
+    margin-right: 20px;
 }
 
 .tiles, .spocs {

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -10,6 +10,17 @@
     <h1>MARS Ads Preview</h1>
 
     <form>
+        <label for="env">Environment</label>&nbsp;
+        <select name="env" id="env">
+            {% for anEnv in environments %}
+                {% if anEnv.code == environment %}
+                <option value="{{ anEnv.code }}" selected="selected">{{ anEnv.name }}</option>
+                {% else %}
+                <option value="{{ anEnv.code }}">{{ anEnv.name }}</option>
+                {% endif %}
+            {% endfor %}
+        </select>
+
         <label for="country">Country</label>&nbsp;
         <select name="country" id="country">
             {% for aCountry in countries %}


### PR DESCRIPTION
## References

JIRA: [AE-388](https://mozilla-hub.atlassian.net/browse/AE-388)

## Description

This is a follow-up to #196 to tweak the previews page:

1. It fixes the styling of Tiles such that long tile titles get correctly truncated.
2. It adds an Environment drop-down to let users pick between 3 environments:
    * Dev uses MARS Staging, and the dev network and site in Kevel
    * Preview uses MARS Prod, and the preview/staging site in the Kevel prod network
    * Prod uses MARS Prod and the prod network and site in Kevel

With this change we no longer use the MARS_URL environment variable, which I'll remove after this lands.

<img width="754" alt="Screenshot 2024-05-23 at 3 12 26 PM" src="https://github.com/mozilla-services/consvc-shepherd/assets/13085/20fa7050-cd71-4241-9b91-919dad45c311">

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [x] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [x] Functional and performance test coverage has been expanded and maintained (if applicable).

[AE-388]: https://mozilla-hub.atlassian.net/browse/AE-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ