### PR TITLE
Add unified api options to preview page

### DIFF
--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -76,6 +76,7 @@ class Tile:
 @dataclass(frozen=True)
 class Ads:
     """Model for all the sets of ads that can be rendered in the preview template"""
+
     tiles: list[Tile]
     spocs: list[Spoc]
 
@@ -295,9 +296,7 @@ def get_unified(env: Environment, country: str) -> Ads:
     )
 
 
-def get_ads(
-    env: Environment, country: str, region: str
-) -> Ads:
+def get_ads(env: Environment, country: str, region: str) -> Ads:
     """Based on Environment, either load spocs & tiles individually or from a single request"""
     if env.code.startswith("unified_"):
         return get_unified(env, country)

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -50,7 +50,7 @@ class Environment:
     code: str
     name: str
     mars_url: str
-    spoc_site_id: int|None
+    spoc_site_id: int | None
 
 
 @dataclass(frozen=True)
@@ -242,7 +242,7 @@ def get_tiles(env: Environment, country: str, region: str) -> list[Tile]:
     ]
 
 
-def get_unified(env: Environment, country: str) -> dict[str, list[Spoc]|list[Tile]]:
+def get_unified(env: Environment, country: str) -> dict[str, list[Spoc] | list[Tile]]:
     """Load Ads from MARS unified api"""
     user_context_id = uuid.uuid4()
 
@@ -253,14 +253,11 @@ def get_unified(env: Environment, country: str) -> dict[str, list[Spoc]|list[Til
 
     # load spocs & tiles, then map them to the same shape
     body = {
-        "user_context_id": f"{user_context_id}", # UUID -> str
-        "placements": [{
-            "placement": spocs_placement,
-            "count": 10
-        }, {
-            "placement": tiles_placement,
-            "count": 3
-        }]
+        "user_context_id": f"{user_context_id}",  # UUID -> str
+        "placements": [
+            {"placement": spocs_placement, "count": 10},
+            {"placement": tiles_placement, "count": 3},
+        ],
     }
 
     r = requests.post(f"{env.mars_url}/v1/ads", json=body, timeout=30)
@@ -291,7 +288,9 @@ def get_unified(env: Environment, country: str) -> dict[str, list[Spoc]|list[Til
     }
 
 
-def get_ads(env: Environment, country: str, region: str) -> dict[str, list[Spoc]|list[Tile]]:
+def get_ads(
+    env: Environment, country: str, region: str
+) -> dict[str, list[Spoc] | list[Tile]]:
     """Based on Environment, either load spocs & tiles individually or from a single request"""
     if env.code.startswith("unified_"):
         return get_unified(env, country)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,3 +82,8 @@ add-select = ["D212"]
 add-ignore = ["D105","D107","D203", "D205", "D400"]
 # '^(?!migrations).*' ignores all Django-generated migration files
 match-dir = '^(?!migrations).*'
+
+[tool.coverage.run]
+omit = [
+    "consvc_shepherd/preview.py"
+]

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -44,7 +44,7 @@
 
     <h2>Tiles</h2>
     <div class="tiles">
-        {% for tile in tiles %}
+        {% for tile in ads.tiles %}
             <div class="tile">
                 <div class="tile-outer">
                     <img class="tile-image" src="{{ tile.image_url }}" alt="{{ tile.name }}"/>
@@ -59,7 +59,7 @@
 
     <h2>SPOCs</h2>
     <div class="spocs">
-        {% for spoc in spocs %}
+        {% for spoc in ads.spocs %}
             <div class="spoc">
                 <img class="spoc-image" src="{{ spoc.image_src }}" alt="{{ spoc.title }}"/>
                 <div class="spoc-meta">


### PR DESCRIPTION
[AE-421](https://mozilla-hub.atlassian.net/browse/AE-421)
- ads being requested via unified api, not yet mapping response to the same shape
- removed preview env since those placements don't yet exist, map response to tile/spoc for preview page, pass in country to enable the translation

### problem
We want to be able to preview the unified api, and now that we have the preview page that is a good first use case to see the API return spocs and tiles in order for them to be rendered there.

### solution
Add new environments for similar scenarios but served via the unified api.

Note: the country/region dropdown currently does not get passed through the request; the ability to override regions & countries for testing purposes is still TBD in unified api.

The country dropdown only modifies the translated string rendered when picking one of the unified api environments.

spocs & kevel-sold tile from dev kevel network
![Screenshot 2024-06-11 at 2 12 57 PM](https://github.com/mozilla-services/consvc-shepherd/assets/808253/6070ad3c-083d-4f68-97b6-14b556d56189)

spocs & kevel-sold tile from prod kevel network
![Screenshot 2024-06-11 at 2 13 07 PM](https://github.com/mozilla-services/consvc-shepherd/assets/808253/658637f2-c2ab-4992-b36c-8bf8a3fd4608)

spocs & kevel-sold tile from dev kevel network, with the sponsored by text translated
![Screenshot 2024-06-11 at 2 13 20 PM](https://github.com/mozilla-services/consvc-shepherd/assets/808253/121dd646-0cba-4731-9e73-0abf450c7cda)


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [x] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [x] Functional and performance test coverage has been expanded and maintained (if applicable).

[AE-421]: https://mozilla-hub.atlassian.net/browse/AE-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ