### PR TITLE
update tiles reponse parsing for unified api preview page

### DIFF
--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -273,7 +273,7 @@ def get_unified(env: Environment, country: str) -> Ads:
     tiles = [
         Tile(
             image_url=tile["image_url"],
-            name=tile["sponsor"],
+            name=tile["name"],
             sponsored=LOCALIZATIONS["Sponsored"][country],
         )
         for tile in r.json().get(tiles_placement, [])


### PR DESCRIPTION
## References

[AE-421](https://mozilla-hub.atlassian.net/browse/AE-421)

## Description
follow up from https://github.com/mozilla-services/consvc-shepherd/pull/200

the tiles format has now been created, so responses to the tiles placement will be in that shape.

related
https://github.com/mozilla-services/mars/pull/165
https://github.com/mozilla-services/mars/blob/main/unified_ads_api/formats.go#L75-L80

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [x] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [x] Functional and performance test coverage has been expanded and maintained (if applicable).

[AE-421]: https://mozilla-hub.atlassian.net/browse/AE-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ