### PR TITLE
[AE-416] Show direct sold tiles on preview page

### DIFF
--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -349,8 +349,7 @@ def get_ads(env: Environment, country: str, region: str) -> Ads:
         spocs_and_direct_sold_tiles = get_spocs_and_direct_sold_tiles(
             env, country, region
         )
-        print("spocs and direct sold tiles")
-        print(spocs_and_direct_sold_tiles)
+
         return Ads(
             tiles=amp_tiles + spocs_and_direct_sold_tiles[0],
             spocs=spocs_and_direct_sold_tiles[1],

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -7,7 +7,6 @@ from typing import TypedDict
 import requests
 from django.views.generic import TemplateView
 
-
 # Localized strings from https://hg.mozilla.org/l10n-central/
 #
 # See e.g. https://hg.mozilla.org/l10n-central/es-ES/file/tip/browser/browser/newtab/newtab.ftl
@@ -258,7 +257,10 @@ def get_tiles(env: Environment, country: str, region: str) -> list[Tile]:
         for tile in r.json().get("tiles", [])
     ]
 
-def get_direct_sold_tiles(env: Environment, country: str, region: str) -> list[DirectSoldTile]:
+
+def get_direct_sold_tiles(
+    env: Environment, country: str, region: str
+) -> list[DirectSoldTile]:
     """Load Direct Sold Tiles (aka Sponsored Topsites) from MARS for given country and region"""
     # Generate a unique pocket ID per request to avoid frequency capping
     pocket_id = uuid.uuid4()
@@ -273,9 +275,9 @@ def get_direct_sold_tiles(env: Environment, country: str, region: str) -> list[D
             {
                 "name": "sponsored-topsites",
                 "zone_ids": [307565],
-                "ad_types": [2401, 3617]
+                "ad_types": [2401, 3617],
             }
-        ]
+        ],
     }
 
     r = requests.post(f"{env.mars_url}/spocs", json=body, timeout=30)
@@ -332,11 +334,7 @@ def get_unified(env: Environment, country: str) -> Ads:
         for spoc in r.json().get(spocs_placement, [])
     ]
 
-    return Ads(
-        spocs=spocs,
-        tiles=tiles,
-        direct_sold_tiles=[]
-    )
+    return Ads(spocs=spocs, tiles=tiles, direct_sold_tiles=[])
 
 
 def get_ads(env: Environment, country: str, region: str) -> Ads:
@@ -347,7 +345,7 @@ def get_ads(env: Environment, country: str, region: str) -> Ads:
         return Ads(
             spocs=get_spocs(env, country, region),
             tiles=get_tiles(env, country, region),
-            direct_sold_tiles=get_direct_sold_tiles(env, country, region)
+            direct_sold_tiles=get_direct_sold_tiles(env, country, region),
         )
 
 

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -341,10 +341,11 @@ def get_ads(env: Environment, country: str, region: str) -> Ads:
     if env.code.startswith("unified_"):
         return get_unified(env, country)
     else:
+        tiles = get_tiles(env, country, region)
+        direct_sold_tiles = get_direct_sold_tiles(env, country, region)
         return Ads(
             spocs=get_spocs(env, country, region),
-            tiles=get_tiles(env, country, region)
-            + get_direct_sold_tiles(env, country, region),
+            tiles=tiles + direct_sold_tiles,
         )
 
 
@@ -368,7 +369,7 @@ def find_env_by_code(env_code: str) -> Environment:
 
 
 def resize_direct_sold_tile_image_url(img_url: str, w: int, h: int) -> str:
-    """Modifies an image url query parameters to the requested size"""
+    """Modify an image url query parameters to the requested size"""
     new_resize_query = {"resize": ["w{}-h{}".format(w, h)]}
 
     parsed_url = urlparse(img_url)

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -7,7 +7,6 @@ from typing import TypedDict
 import requests
 from django.views.generic import TemplateView
 
-import sys
 
 # Localized strings from https://hg.mozilla.org/l10n-central/
 #
@@ -65,11 +64,13 @@ class Spoc:
     excerpt: str
     sponsored_by: str
 
+
 @dataclass(frozen=True)
 class DirectSoldTile(Spoc):
     """Model for a Direct Sold Tile aka Sponsored Topsite loaded from MARS"""
 
     pass
+
 
 @dataclass(frozen=True)
 class Tile:
@@ -79,6 +80,7 @@ class Tile:
     name: str
     sponsored: str
 
+
 @dataclass(frozen=True)
 class Ads:
     """Model for all the sets of ads that can be rendered in the preview template"""
@@ -86,6 +88,7 @@ class Ads:
     tiles: list[Tile]
     spocs: list[Spoc]
     direct_sold_tiles: list[DirectSoldTile]
+
 
 # Ad environments. Note that these differ from MARS or Shepherd environments.
 ENVIRONMENTS: list[Environment] = [
@@ -266,7 +269,7 @@ def get_direct_sold_tiles(env: Environment, country: str, region: str) -> list[D
         "version": 2,
         "country": country,
         "region": region,
-        "placements":  [
+        "placements": [
             {
                 "name": "sponsored-topsites",
                 "zone_ids": [307565],
@@ -276,8 +279,6 @@ def get_direct_sold_tiles(env: Environment, country: str, region: str) -> list[D
     }
 
     r = requests.post(f"{env.mars_url}/spocs", json=body, timeout=30)
-    print(f'json from get_sponsored_topsites /spocs response status {r.status_code}', file=sys.stderr)
-    print(f'json from get_sponsored_topsites /spocs {r.json()}', file=sys.stderr)
 
     return [
         DirectSoldTile(

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -92,21 +92,22 @@ ENVIRONMENTS: list[Environment] = [
         name="Dev",
         mars_url="https://mars.stage.ads.nonprod.webservices.mozgcp.net",
         spoc_site_id=1276332,
-        direct_sold_tile_zone_id=317832,  # In Kevel > Network: MozAds-Dev, Site: Firefox Experiments corollary, Zone: Tiles"
+        direct_sold_tile_zone_id=317828,  # In Kevel > Network: MozAds-Dev, Site: Firefox Production corollary, Zone: Tiles
     ),
     Environment(
         code="preview",
         name="Preview",
         mars_url="https://mars.prod.ads.prod.webservices.mozgcp.net",
         spoc_site_id=1084367,
-        direct_sold_tile_zone_id=317828,  # In Kevel > Newtork: MozAds-Dev, Site: Firefox Production corollary, Zone: Tiles
+        direct_sold_tile_zone_id=None,  # In Kevel > Network: Pocket, Site: Firefox Staging, Zone: Tiles
+        # The above zone doesn't actually exist in Kevel yet, so we need to udpate this value once we create the zone.
     ),
     Environment(
         code="production",
         name="Production",
         mars_url="https://mars.prod.ads.prod.webservices.mozgcp.net",
         spoc_site_id=1070098,
-        direct_sold_tile_zone_id=280143,  # In Kevel > Network: Pocket, Site: Firefox Production,  Zone: Tiles
+        direct_sold_tile_zone_id=280143,  # In Kevel > Network: Pocket, Site: Firefox Production, Zone: Tiles
     ),
     Environment(
         code="unified_dev",
@@ -234,7 +235,7 @@ def get_spocs(env: Environment, country: str, region: str) -> list[Spoc]:
     ]
 
 
-def get_tiles(env: Environment, country: str, region: str) -> list[Tile]:
+def get_amp_tiles(env: Environment, country: str, region: str) -> list[Tile]:
     """Load Sponsored Tiles from MARS for given country and region"""
     params = {
         "country": country,
@@ -261,6 +262,9 @@ def get_tiles(env: Environment, country: str, region: str) -> list[Tile]:
 
 def get_direct_sold_tiles(env: Environment, country: str, region: str) -> list[Tile]:
     """Request Direct Sold Tiles (aka Sponsored Topsites) from MARS for given country and region"""
+    if env.direct_sold_tile_zone_id is None:
+        return []
+
     # Generate a unique pocket ID per request to avoid frequency capping
     pocket_id = uuid.uuid4()
 
@@ -341,11 +345,11 @@ def get_ads(env: Environment, country: str, region: str) -> Ads:
     if env.code.startswith("unified_"):
         return get_unified(env, country)
     else:
-        tiles = get_tiles(env, country, region)
+        amp_tiles = get_amp_tiles(env, country, region)
         direct_sold_tiles = get_direct_sold_tiles(env, country, region)
         return Ads(
             spocs=get_spocs(env, country, region),
-            tiles=tiles + direct_sold_tiles,
+            tiles=amp_tiles + direct_sold_tiles,
         )
 
 

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -65,6 +65,11 @@ class Spoc:
     excerpt: str
     sponsored_by: str
 
+@dataclass(frozen=True)
+class DirectSoldTile(Spoc):
+    """Model for a Direct Sold Tile aka Sponsored Topsite loaded from MARS"""
+
+    pass
 
 @dataclass(frozen=True)
 class Tile:
@@ -75,22 +80,12 @@ class Tile:
     sponsored: str
 
 @dataclass(frozen=True)
-class SponsoredTopsite:
-    """Model for a Sponsored Topsite (aka Direct Sold Tile) loaded from MARS"""
-
-    image_src: str
-    title: str
-    domain: str
-    excerpt: str
-    sponsored_by: str
-
-@dataclass(frozen=True)
 class Ads:
     """Model for all the sets of ads that can be rendered in the preview template"""
 
     tiles: list[Tile]
     spocs: list[Spoc]
-    sponsored_topsites: list[SponsoredTopsite]
+    direct_sold_tiles: list[DirectSoldTile]
 
 # Ad environments. Note that these differ from MARS or Shepherd environments.
 ENVIRONMENTS: list[Environment] = [
@@ -260,8 +255,8 @@ def get_tiles(env: Environment, country: str, region: str) -> list[Tile]:
         for tile in r.json().get("tiles", [])
     ]
 
-def get_sponsored_topsites(env: Environment, country: str, region: str) -> list[SponsoredTopsite]:
-    """Load Sponsored Topsites / Direct Sold tiles from MARS for given country and region"""
+def get_direct_sold_tiles(env: Environment, country: str, region: str) -> list[DirectSoldTile]:
+    """Load Direct Sold Tiles (aka Sponsored Topsites) from MARS for given country and region"""
     # Generate a unique pocket ID per request to avoid frequency capping
     pocket_id = uuid.uuid4()
 
@@ -285,7 +280,7 @@ def get_sponsored_topsites(env: Environment, country: str, region: str) -> list[
     print(f'json from get_sponsored_topsites /spocs {r.json()}', file=sys.stderr)
 
     return [
-        SponsoredTopsite(
+        DirectSoldTile(
             image_src=spoc["image_src"],
             title=spoc["title"],
             domain=spoc["domain"],
@@ -339,7 +334,7 @@ def get_unified(env: Environment, country: str) -> Ads:
     return Ads(
         spocs=spocs,
         tiles=tiles,
-        sponsored_topsites=[]
+        direct_sold_tiles=[]
     )
 
 
@@ -351,7 +346,7 @@ def get_ads(env: Environment, country: str, region: str) -> Ads:
         return Ads(
             spocs=get_spocs(env, country, region),
             tiles=get_tiles(env, country, region),
-            sponsored_topsites=get_sponsored_topsites(env, country, region)
+            direct_sold_tiles=get_direct_sold_tiles(env, country, region)
         )
 
 

--- a/consvc_shepherd/tests/test_preview.py
+++ b/consvc_shepherd/tests/test_preview.py
@@ -4,61 +4,102 @@ from django.test import TestCase, override_settings
 
 from consvc_shepherd.preview import Environment, Spoc, Tile, get_ads
 
+SPOC: Spoc = Spoc(
+    image_src="https://picsum.photos/296/148",
+    title="There is a Sale",
+    domain="cosmetics.beauty",
+    excerpt="The sale has begun...",
+    sponsored_by="Sponsored by Cosmetics",
+)
+
+ACME_TILE: Tile = Tile(
+    image_url="https://picsum.photos/id/200/48/48",
+    name="ACME",
+    sponsored="Sponsored",
+)
+
+ZOMBOCOM_TILE: Tile = Tile(
+    image_url="https://picsum.photos/id/237/48/48",
+    name="Zombocom",
+    sponsored="Sponsored",
+)
+
+PROGRESS_QUEST_TILE: Tile = Tile(
+    image_url="https://picsum.photos/id/40/48/48",
+    name="Progress Quest",
+    sponsored="Sponsored",
+)
+
 
 @override_settings(DEBUG=True)
 class TestGetAds(TestCase):
 
-    def mock_get_tiles(*args) -> list[Tile]:
-        """Mock out either type of request for tiles within get_ads ('GET /v1/tiles' or 'POST /spocs for sponsored-topsites')"""
-        print("mock get_tiles")
-        return [
-                Tile(
-                    image_url="https://picsum.photos/48",
-                    name="ACME",
-                    sponsored="Sponsored",
-                ),
-                Tile(
-                    image_url="https://picsum.photos/48",
-                    name="Zombocom",
-                    sponsored="Sponsored",
-                )
-            ]
+    def mock_get_tiles(self, *args) -> list[Tile]:
+        """Mock out the function that wraps 'GET /v1/tiles' request within get_ads"""
+        return [ACME_TILE, ZOMBOCOM_TILE]
+
+    def mock_get_direct_sold_tiles(self, *args) -> list[Tile]:
+        """Mock out the function that wraps 'POST /spocs' request for 'sponsored-topsites'"""
+        return [PROGRESS_QUEST_TILE]
 
     def mock_get_spocs(self, *args) -> list[Spoc]:
         """Mock out the POST /spocs requests within get_ads"""
-        print("mock get_spocs")
-        return [
-            Spoc(
-                image_src="https://picsum.photos/296/148",
-                title="There is a Sale",
-                domain="cosmetics.beauty",
-                excerpt="The sale has begun..",
-                sponsored_by="Sponsored by Cosmetics",
-            ),
-
-        ]
+        return [SPOC]
 
     def test_get_ads(self):
         """Test of the get_ads function that backs the preview page."""
         with mock.patch(
             "consvc_shepherd.preview.get_spocs", side_effect=self.mock_get_spocs
-        ):
+        ) as mock_get_spocs:
             with mock.patch(
                 "consvc_shepherd.preview.get_tiles", side_effect=self.mock_get_tiles
-            ):
+            ) as mock_get_tiles:
                 with mock.patch(
-                    "consvc_shepherd.preview.get_direct_sold_tiles", side_effect=self.mock_get_tiles
-                ):
+                    "consvc_shepherd.preview.get_direct_sold_tiles",
+                    side_effect=self.mock_get_direct_sold_tiles,
+                ) as mock_get_direct_sold_tiles:
                     mockEnv = Environment(
                         code="mock",
                         name="Mock",
                         mars_url="https://mars.mock.if.you.are.connecting.to.this.the.test.broke.com",
                         spoc_site_id=1234567,
-                        direct_sold_tile_zone_id=424242)
+                        direct_sold_tile_zone_id=424242,
+                    )
                     ads = get_ads(mockEnv, "US", "CA")
-                    print("ads")
-                    print(ads)
 
+                    # Function calls
+                    mock_get_spocs.assert_called_once_with(mockEnv, "US", "CA")
+                    mock_get_tiles.assert_called_once_with(mockEnv, "US", "CA")
+                    mock_get_direct_sold_tiles.assert_called_once_with(
+                        mockEnv, "US", "CA"
+                    )
+                    self.assertEqual(len(ads.spocs), 1)
+                    self.assertEqual(len(ads.tiles), 3)
 
-# Test that expected get_*s are called based on env param unified or other
-# Test that response are processed correctly in the Ads object
+                    # Spoc data
+                    self.assertEqual(ads.spocs[0].image_src, SPOC.image_src)
+                    self.assertEqual(ads.spocs[0].title, SPOC.title)
+                    self.assertEqual(ads.spocs[0].domain, SPOC.domain)
+                    self.assertEqual(ads.spocs[0].excerpt, SPOC.excerpt)
+                    self.assertEqual(ads.spocs[0].sponsored_by, SPOC.sponsored_by)
+
+                    # Tile data
+                    self.assertEqual(
+                        ads.tiles[2].image_url, "https://picsum.photos/id/40/48/48"
+                    )
+                    self.assertEqual(ads.tiles[2].name, "Progress Quest")
+                    self.assertEqual(ads.tiles[2].sponsored, "Sponsored")
+
+    def test_get_ads_unified_env(self):
+        """Test that when unified API environments are requested, the expected request wrapper functions are called"""
+        with mock.patch("consvc_shepherd.preview.get_unified") as mock_get_unified:
+            mockUnifiedEnv = Environment(
+                code="unified_mock",
+                name="Unified Mock",
+                mars_url="https://unified.mock.if.you.are.connecting.to.this.the.test.broke.com",
+                spoc_site_id=1234567,
+                direct_sold_tile_zone_id=424242,
+            )
+            ads = get_ads(mockUnifiedEnv, "US", "CA")
+
+            mock_get_unified.assert_called_once_with(mockUnifiedEnv, "US")

--- a/consvc_shepherd/tests/test_preview.py
+++ b/consvc_shepherd/tests/test_preview.py
@@ -37,7 +37,7 @@ PROGRESS_QUEST_TILE: Tile = Tile(
 class TestGetAds(TestCase):
     """Test the fetching of various ads on the preview page"""
 
-    def mock_get_tiles(self, *args) -> list[Tile]:
+    def mock_get_amp_tiles(self, *args) -> list[Tile]:
         """Mock out the function that wraps 'GET /v1/tiles' request within get_ads"""
         return [ACME_TILE, ZOMBOCOM_TILE]
 
@@ -55,8 +55,9 @@ class TestGetAds(TestCase):
             "consvc_shepherd.preview.get_spocs", side_effect=self.mock_get_spocs
         ) as mock_get_spocs:
             with mock.patch(
-                "consvc_shepherd.preview.get_tiles", side_effect=self.mock_get_tiles
-            ) as mock_get_tiles:
+                "consvc_shepherd.preview.get_amp_tiles",
+                side_effect=self.mock_get_amp_tiles,
+            ) as mock_get_amp_tiles:
                 with mock.patch(
                     "consvc_shepherd.preview.get_direct_sold_tiles",
                     side_effect=self.mock_get_direct_sold_tiles,
@@ -72,7 +73,7 @@ class TestGetAds(TestCase):
 
                     # Function calls
                     mock_get_spocs.assert_called_once_with(mockEnv, "US", "CA")
-                    mock_get_tiles.assert_called_once_with(mockEnv, "US", "CA")
+                    mock_get_amp_tiles.assert_called_once_with(mockEnv, "US", "CA")
                     mock_get_direct_sold_tiles.assert_called_once_with(
                         mockEnv, "US", "CA"
                     )

--- a/consvc_shepherd/tests/test_preview.py
+++ b/consvc_shepherd/tests/test_preview.py
@@ -1,3 +1,5 @@
+"""Unit tests for the preview page functionalities"""
+
 from unittest import mock
 
 from django.test import TestCase, override_settings
@@ -33,6 +35,7 @@ PROGRESS_QUEST_TILE: Tile = Tile(
 
 @override_settings(DEBUG=True)
 class TestGetAds(TestCase):
+    """Test the fetching of various ads on the preview page"""
 
     def mock_get_tiles(self, *args) -> list[Tile]:
         """Mock out the function that wraps 'GET /v1/tiles' request within get_ads"""
@@ -100,6 +103,6 @@ class TestGetAds(TestCase):
                 spoc_site_id=1234567,
                 direct_sold_tile_zone_id=424242,
             )
-            ads = get_ads(mockUnifiedEnv, "US", "CA")
+            get_ads(mockUnifiedEnv, "US", "CA")
 
             mock_get_unified.assert_called_once_with(mockUnifiedEnv, "US")

--- a/consvc_shepherd/tests/test_preview.py
+++ b/consvc_shepherd/tests/test_preview.py
@@ -1,0 +1,64 @@
+from unittest import mock
+
+from django.test import TestCase, override_settings
+
+from consvc_shepherd.preview import Environment, Spoc, Tile, get_ads
+
+
+@override_settings(DEBUG=True)
+class TestGetAds(TestCase):
+
+    def mock_get_tiles(*args) -> list[Tile]:
+        """Mock out either type of request for tiles within get_ads ('GET /v1/tiles' or 'POST /spocs for sponsored-topsites')"""
+        print("mock get_tiles")
+        return [
+                Tile(
+                    image_url="https://picsum.photos/48",
+                    name="ACME",
+                    sponsored="Sponsored",
+                ),
+                Tile(
+                    image_url="https://picsum.photos/48",
+                    name="Zombocom",
+                    sponsored="Sponsored",
+                )
+            ]
+
+    def mock_get_spocs(self, *args) -> list[Spoc]:
+        """Mock out the POST /spocs requests within get_ads"""
+        print("mock get_spocs")
+        return [
+            Spoc(
+                image_src="https://picsum.photos/296/148",
+                title="There is a Sale",
+                domain="cosmetics.beauty",
+                excerpt="The sale has begun..",
+                sponsored_by="Sponsored by Cosmetics",
+            ),
+
+        ]
+
+    def test_get_ads(self):
+        """Test of the get_ads function that backs the preview page."""
+        with mock.patch(
+            "consvc_shepherd.preview.get_spocs", side_effect=self.mock_get_spocs
+        ):
+            with mock.patch(
+                "consvc_shepherd.preview.get_tiles", side_effect=self.mock_get_tiles
+            ):
+                with mock.patch(
+                    "consvc_shepherd.preview.get_direct_sold_tiles", side_effect=self.mock_get_tiles
+                ):
+                    mockEnv = Environment(
+                        code="mock",
+                        name="Mock",
+                        mars_url="https://mars.mock.if.you.are.connecting.to.this.the.test.broke.com",
+                        spoc_site_id=1234567,
+                        direct_sold_tile_zone_id=424242)
+                    ads = get_ads(mockEnv, "US", "CA")
+                    print("ads")
+                    print(ads)
+
+
+# Test that expected get_*s are called based on env param unified or other
+# Test that response are processed correctly in the Ads object

--- a/consvc_shepherd/tests/test_preview.py
+++ b/consvc_shepherd/tests/test_preview.py
@@ -6,7 +6,7 @@ from django.test import TestCase, override_settings
 
 from consvc_shepherd.preview import Environment, Spoc, Tile, get_ads
 
-SPOC: Spoc = Spoc(
+SPOC = Spoc(
     image_src="https://picsum.photos/296/148",
     title="There is a Sale",
     domain="cosmetics.beauty",
@@ -14,19 +14,19 @@ SPOC: Spoc = Spoc(
     sponsored_by="Sponsored by Cosmetics",
 )
 
-ACME_TILE: Tile = Tile(
+ACME_TILE = Tile(
     image_url="https://picsum.photos/id/200/48/48",
     name="ACME",
     sponsored="Sponsored",
 )
 
-ZOMBOCOM_TILE: Tile = Tile(
+ZOMBOCOM_TILE = Tile(
     image_url="https://picsum.photos/id/237/48/48",
     name="Zombocom",
     sponsored="Sponsored",
 )
 
-PROGRESS_QUEST_TILE: Tile = Tile(
+PROGRESS_QUEST_TILE = Tile(
     image_url="https://picsum.photos/id/40/48/48",
     name="Progress Quest",
     sponsored="Sponsored",

--- a/consvc_shepherd/tests/test_preview.py
+++ b/consvc_shepherd/tests/test_preview.py
@@ -41,58 +41,53 @@ class TestGetAds(TestCase):
         """Mock out the function that wraps 'GET /v1/tiles' request within get_ads"""
         return [ACME_TILE, ZOMBOCOM_TILE]
 
-    def mock_get_direct_sold_tiles(self, *args) -> list[Tile]:
-        """Mock out the function that wraps 'POST /spocs' request for 'sponsored-topsites'"""
-        return [PROGRESS_QUEST_TILE]
-
-    def mock_get_spocs(self, *args) -> list[Spoc]:
+    def mock_get_spocs_and_direct_sold_tiles(
+        self, *args
+    ) -> tuple[list[Tile], list[Spoc]]:
         """Mock out the POST /spocs requests within get_ads"""
-        return [SPOC]
+        return ([PROGRESS_QUEST_TILE], [SPOC])
 
     def test_get_ads(self):
         """Test of the get_ads function that backs the preview page."""
         with mock.patch(
-            "consvc_shepherd.preview.get_spocs", side_effect=self.mock_get_spocs
-        ) as mock_get_spocs:
+            "consvc_shepherd.preview.get_spocs_and_direct_sold_tiles",
+            side_effect=self.mock_get_spocs_and_direct_sold_tiles,
+        ) as mock_get_spocs_and_direct_sold_tiles:
             with mock.patch(
                 "consvc_shepherd.preview.get_amp_tiles",
                 side_effect=self.mock_get_amp_tiles,
             ) as mock_get_amp_tiles:
-                with mock.patch(
-                    "consvc_shepherd.preview.get_direct_sold_tiles",
-                    side_effect=self.mock_get_direct_sold_tiles,
-                ) as mock_get_direct_sold_tiles:
-                    mockEnv = Environment(
-                        code="mock",
-                        name="Mock",
-                        mars_url="https://mars.mock.if.you.are.connecting.to.this.the.test.broke.com",
-                        spoc_site_id=1234567,
-                        direct_sold_tile_zone_id=424242,
-                    )
-                    ads = get_ads(mockEnv, "US", "CA")
+                mockEnv = Environment(
+                    code="mock",
+                    name="Mock",
+                    mars_url="https://mars.mock.if.you.are.connecting.to.this.the.test.broke.com",
+                    spoc_site_id=1234567,
+                    spoc_zone_ids=[],
+                    direct_sold_tile_zone_ids=[424242],
+                )
+                ads = get_ads(mockEnv, "US", "CA")
 
-                    # Function calls
-                    mock_get_spocs.assert_called_once_with(mockEnv, "US", "CA")
-                    mock_get_amp_tiles.assert_called_once_with(mockEnv, "US", "CA")
-                    mock_get_direct_sold_tiles.assert_called_once_with(
-                        mockEnv, "US", "CA"
-                    )
-                    self.assertEqual(len(ads.spocs), 1)
-                    self.assertEqual(len(ads.tiles), 3)
+                # Function calls
+                mock_get_amp_tiles.assert_called_once_with(mockEnv, "US", "CA")
+                mock_get_spocs_and_direct_sold_tiles.assert_called_once_with(
+                    mockEnv, "US", "CA"
+                )
+                self.assertEqual(len(ads.spocs), 1)
+                self.assertEqual(len(ads.tiles), 3)
 
-                    # Spoc data
-                    self.assertEqual(ads.spocs[0].image_src, SPOC.image_src)
-                    self.assertEqual(ads.spocs[0].title, SPOC.title)
-                    self.assertEqual(ads.spocs[0].domain, SPOC.domain)
-                    self.assertEqual(ads.spocs[0].excerpt, SPOC.excerpt)
-                    self.assertEqual(ads.spocs[0].sponsored_by, SPOC.sponsored_by)
+                # Spoc data
+                self.assertEqual(ads.spocs[0].image_src, SPOC.image_src)
+                self.assertEqual(ads.spocs[0].title, SPOC.title)
+                self.assertEqual(ads.spocs[0].domain, SPOC.domain)
+                self.assertEqual(ads.spocs[0].excerpt, SPOC.excerpt)
+                self.assertEqual(ads.spocs[0].sponsored_by, SPOC.sponsored_by)
 
-                    # Tile data
-                    self.assertEqual(
-                        ads.tiles[2].image_url, "https://picsum.photos/id/40/48/48"
-                    )
-                    self.assertEqual(ads.tiles[2].name, "Progress Quest")
-                    self.assertEqual(ads.tiles[2].sponsored, "Sponsored")
+                # Tile data
+                self.assertEqual(
+                    ads.tiles[2].image_url, "https://picsum.photos/id/40/48/48"
+                )
+                self.assertEqual(ads.tiles[2].name, "Progress Quest")
+                self.assertEqual(ads.tiles[2].sponsored, "Sponsored")
 
     def test_get_ads_unified_env(self):
         """Test that when unified API environments are requested, the expected request wrapper functions are called"""
@@ -102,7 +97,8 @@ class TestGetAds(TestCase):
                 name="Unified Mock",
                 mars_url="https://unified.mock.if.you.are.connecting.to.this.the.test.broke.com",
                 spoc_site_id=1234567,
-                direct_sold_tile_zone_id=424242,
+                spoc_zone_ids=[1010101],
+                direct_sold_tile_zone_ids=[424242],
             )
             get_ads(mockUnifiedEnv, "US", "CA")
 

--- a/consvc_shepherd/tests/test_views.py
+++ b/consvc_shepherd/tests/test_views.py
@@ -10,7 +10,7 @@ from consvc_shepherd.models import (
     PartnerAllocation,
     SettingsSnapshot,
 )
-from consvc_shepherd.preview import Ads, DirectSoldTile, Spoc, Tile
+from consvc_shepherd.preview import Ads, Spoc, Tile
 from contile.models import Partner
 
 
@@ -155,27 +155,24 @@ class TestPreviewView(TestCase):
         """Create some mock ads data to assert against in the preview view"""
         tile = Tile(
             image_url="https://picsum.photos/48",
-            name="Expandia",
+            name="ACME",
+            sponsored="Sponsored",
+        )
+        direct_sold_tile = Tile(
+            image_url="https://picsum.photos/48",
+            name="Zombocom",
             sponsored="Sponsored",
         )
         spoc = Spoc(
             image_src="https://picsum.photos/296/148",
-            title="Play Forge of Fiefdoms Now for Free",
-            domain="play.forgeoffiefdoms.com",
-            excerpt="If you like to play, this fief-building game is a must-have.",
-            sponsored_by="Forge of Fiefdoms",
-        )
-        directSoldTile = DirectSoldTile(
-            image_src="https://picsum.photos/296/148",
-            title="Don't Borrow From The Bank If You Own a Home, Do This Instead (It's Genius)",
-            domain="lendgogo.com",
-            excerpt="Get cash for your home's equity without affecting your current mortgage rate.",
-            sponsored_by="Lendgogo",
+            title="Play Anvil of the Ages Now for Free",
+            domain="play.anviloftheages.com",
+            excerpt="If you like to play games, then you should play this game.",
+            sponsored_by="Anvil of the Ages",
         )
         return Ads(
-            tiles=[tile],
+            tiles=[tile, direct_sold_tile],
             spocs=[spoc],
-            direct_sold_tiles=[directSoldTile],
         )
 
     def test_preview_view(self):
@@ -185,9 +182,8 @@ class TestPreviewView(TestCase):
         ):
             response = self.client.get("/preview")
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(len(response.context["ads"].tiles), 1)
-            self.assertContains(response, "Expandia")
+            self.assertEqual(len(response.context["ads"].tiles), 2)
+            self.assertContains(response, "ACME")
+            self.assertContains(response, "Zombocom")
             self.assertEqual(len(response.context["ads"].spocs), 1)
-            self.assertContains(response, "Forge of Fiefdoms")
-            self.assertEqual(len(response.context["ads"].direct_sold_tiles), 1)
-            self.assertContains(response, "Lendgogo")
+            self.assertContains(response, "Anvil of the Ages")

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   db:
     tty: true
@@ -33,4 +31,3 @@ services:
 
 volumes:
   db_volume:
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
   db:
-    container_name: consvc-shepherd-db
     tty: true
     restart: always
     image: postgres:14.0
@@ -13,7 +12,6 @@ services:
       - "5432:5432"
 
   app:
-    container_name: consvc-shepherd-app
     tty: true
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: "3"
-
 services:
   db:
+    container_name: consvc-shepherd-db
     tty: true
     restart: always
     image: postgres:14.0
@@ -14,6 +13,7 @@ services:
       - "5432:5432"
 
   app:
+    container_name: consvc-shepherd-app
     tty: true
     env_file:
       - .env
@@ -32,5 +32,3 @@ services:
 
 volumes:
   db_volume:
-
-

--- a/docs/quickStart.md
+++ b/docs/quickStart.md
@@ -16,12 +16,12 @@ eval "$(pyenv virtualenv-init -)"
 ```
 
 4. To run consvc-shepherd, you'll need to specify some minimal configurations.
-Use the existing `.env.example` and rename it to `env`.
+Use the existing `.env.example` and copy it to `.env`.
 You'll want to make sure configuration files in the `.env` file match your database setup, configuring the database name, user, host and password variables.
 It should appear as follows:
 
 ```shell
-$ mv .env.example .env
+$ cp .env.example .env
 
 # Variables to set in file
 DEBUG=true
@@ -40,15 +40,13 @@ $ pyenv install 3.11
 
 # pyenv virtualenv
 $ pyenv virtualenv 3.11 shepherd # or whatever project name you like.
-$ pyenv local shepherd # enables virtual env when you enter directory. 
-
-# Install dependencies
-$ pip install poetry
-$ poetry install
+$ pyenv local shepherd # enables virtual env when you enter directory.
 ```
 
 6. Install your dependencies:
+
 ```shell
+$ pip install poetry
 $ poetry install
 ```
 
@@ -56,17 +54,15 @@ $ poetry install
 
 8. Build the Docker image and start the container:
 ```shell
-docker compose build
-docker compose up
+docker-compose up --build
 ```
 
 The application will then be accessible at the following url: [http://0.0.0.0:7001/](http://0.0.0.0:7001/). The admin panel is available at [http://0.0.0.0:7001/admin](http://0.0.0.0:7001/admin)
 
-9. Create database migrations and run migrations. 
+9. Create database migrations and run migrations.
 You may have to do this periodically as you modify or create models. Shell in as above and run the following commands:
 ``` shell
-docker ps # capture container id for consvc-shepherd
-docker exec -it <CONTAINER ID> sh # interactive mode
-python manage.py makemigrations 
-python manage.py migrate 
+docker exec -it consvc-shepherd-app sh # interactive mode
+python manage.py makemigrations
+python manage.py migrate
 ```

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -73,6 +73,23 @@
             </div>
         {% endfor %}
     </div>
+
+    <h2>Sponsored Topsites</h2>
+    <div class="spocs">
+        {% for sponsored_topsite in ads.sponsored_topsites %}
+            <div class="spoc">
+                <img class="spoc-image" src="{{ sponsored_topsite.image_src }}" alt="{{ sponsored_topsite.title }}"/>
+                <div class="spoc-meta">
+                    <div class="spoc-info">
+                        <div class="spoc-domain clamp">{{ sponsored_topsite.domain }}</div>
+                        <div class="spoc-title clamp">{{ sponsored_topsite.title }}</div>
+                        <div class="spoc-exerpt clamp">{{ sponsored_topsite.excerpt }}</div>
+                    </div>
+                    <div class="spoc-context">{{ spoc.sponsored_by }}</div>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
 </div>
 
 {{ regions|json_script:"regions-data" }}

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -74,18 +74,18 @@
         {% endfor %}
     </div>
 
-    <h2>Sponsored Topsites</h2>
+    <h2>Direct Sold Tiles</h2>
     <div class="spocs">
-        {% for sponsored_topsite in ads.sponsored_topsites %}
+        {% for direct_sold_tile in ads.direct_sold_tiles %}
             <div class="spoc">
-                <img class="spoc-image" src="{{ sponsored_topsite.image_src }}" alt="{{ sponsored_topsite.title }}"/>
+                <img class="spoc-image" src="{{ direct_sold_tile.image_src }}" alt="{{ direct_sold_tile.title }}"/>
                 <div class="spoc-meta">
                     <div class="spoc-info">
-                        <div class="spoc-domain clamp">{{ sponsored_topsite.domain }}</div>
-                        <div class="spoc-title clamp">{{ sponsored_topsite.title }}</div>
-                        <div class="spoc-exerpt clamp">{{ sponsored_topsite.excerpt }}</div>
+                        <div class="spoc-domain clamp">{{ direct_sold_tile.domain }}</div>
+                        <div class="spoc-title clamp">{{ direct_sold_tile.title }}</div>
+                        <div class="spoc-exerpt clamp">{{ direct_sold_tile.excerpt }}</div>
                     </div>
-                    <div class="spoc-context">{{ spoc.sponsored_by }}</div>
+                    <div class="spoc-context">{{ direct_sold_tile.sponsored_by }}</div>
                 </div>
             </div>
         {% endfor %}

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -73,23 +73,6 @@
             </div>
         {% endfor %}
     </div>
-
-    <h2>Direct Sold Tiles</h2>
-    <div class="spocs">
-        {% for direct_sold_tile in ads.direct_sold_tiles %}
-            <div class="spoc">
-                <img class="spoc-image" src="{{ direct_sold_tile.image_src }}" alt="{{ direct_sold_tile.title }}"/>
-                <div class="spoc-meta">
-                    <div class="spoc-info">
-                        <div class="spoc-domain clamp">{{ direct_sold_tile.domain }}</div>
-                        <div class="spoc-title clamp">{{ direct_sold_tile.title }}</div>
-                        <div class="spoc-exerpt clamp">{{ direct_sold_tile.excerpt }}</div>
-                    </div>
-                    <div class="spoc-context">{{ direct_sold_tile.sponsored_by }}</div>
-                </div>
-            </div>
-        {% endfor %}
-    </div>
 </div>
 
 {{ regions|json_script:"regions-data" }}


### PR DESCRIPTION
## References

JIRA: [AE-416](https://mozilla-hub.atlassian.net/browse/AE-416)

## Description

This PR adds adds "direct sold tiles" to the Tiles section on the Preview page, fetched by requesting `sponsored-topsite` placements from the `/spocs` endpoint. In this view, they are added to the right of the tiles coming from `/v1/tiles`.

Note that this new functionality is for showing the direct sold tiles when selecting Preview, Dev, and Prod environments from the dropdown. For unified API, those are pulled in on the backend already, and don't need to be put together by the client.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [X] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [X] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [x] Functional and performance test coverage has been expanded and maintained (if applicable).

[AE-416]: https://mozilla-hub.atlassian.net/browse/AE-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ