### PR TITLE
include user-agent header when requesting ads from unified api

### DIFF
--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -259,6 +259,11 @@ def get_unified(env: Environment, country: str) -> Ads:
     spocs_placement = "newtab_spocs"
     tiles_placement = "newtab_tiles"
 
+    # specify Firefox user-agent header so that newtab_tiles are filled
+    headers = {
+        'user-agent':'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:129.0) Gecko/20100101 Firefox/129.0'
+    }
+
     # load spocs & tiles, then map them to the same shape
     body = {
         "user_context_id": f"{user_context_id}",  # UUID -> str
@@ -268,8 +273,7 @@ def get_unified(env: Environment, country: str) -> Ads:
         ],
     }
 
-    r = requests.post(f"{env.mars_url}/v1/ads", json=body, timeout=30)
-
+    r = requests.post(f"{env.mars_url}/v1/ads", headers=headers, json=body, timeout=30)
     tiles = [
         Tile(
             image_url=tile["image_url"],

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -261,7 +261,7 @@ def get_unified(env: Environment, country: str) -> Ads:
 
     # specify Firefox user-agent header so that newtab_tiles are filled
     headers = {
-        'user-agent':'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:129.0) Gecko/20100101 Firefox/129.0'
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:129.0) Gecko/20100101 Firefox/129.0"
     }
 
     # load spocs & tiles, then map them to the same shape


### PR DESCRIPTION
## Description
ADM tiles aren't showing up on the preview page. This is a side effect of the ADM provider returning no tiles based on the user agent of the request.

## Solution
Include a user-agent header to specify Firefox. Ran locally and confirmed dev unified api & prod unified api now include tiles from ADM. dev shows the test kevel tile campaign, but prod does not reliably have a kevel tile -- that is much more dependent on inventory/country of the request.

![Screenshot 2024-07-08 at 11 31 10 AM](https://github.com/mozilla-services/consvc-shepherd/assets/808253/b7015f7c-dd86-4f81-8260-09e29b2254ce)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [X] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [X] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [X] Functional and performance test coverage has been expanded and maintained (if applicable).