### PR TITLE
[AE-480] Fix SPOC vertical sizing on Preview page

### DIFF
--- a/consvc_shepherd/static/preview/css/preview.css
+++ b/consvc_shepherd/static/preview/css/preview.css
@@ -24,6 +24,11 @@
     margin-right: 20px;
 }
 
+#preview a {
+    text-decoration: none;
+    color: inherit;
+}
+
 .tiles, .spocs {
     display: flex;
     flex-wrap: wrap;
@@ -78,7 +83,7 @@
     font-size: 0.9em;
 }
 
-.spoc, .spoc-info, .spoc-meta {
+.spoc, .spoc-info, .spoc-meta, .spocs a {
     display: flex;
     flex-direction: column;
 }
@@ -91,7 +96,7 @@
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 
-.spoc-info, .spoc-meta {
+.spoc, .spoc-info, .spoc-meta {
     flex-grow: 1;
 }
 

--- a/static/preview/css/preview.css
+++ b/static/preview/css/preview.css
@@ -24,6 +24,11 @@
     margin-right: 20px;
 }
 
+#preview a {
+    text-decoration: none;
+    color: inherit;
+}
+
 .tiles, .spocs {
     display: flex;
     flex-wrap: wrap;
@@ -78,7 +83,7 @@
     font-size: 0.9em;
 }
 
-.spoc, .spoc-info, .spoc-meta {
+.spoc, .spoc-info, .spoc-meta, .spocs a {
     display: flex;
     flex-direction: column;
 }
@@ -91,7 +96,7 @@
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 
-.spoc-info, .spoc-meta {
+.spoc, .spoc-info, .spoc-meta {
     flex-grow: 1;
 }
 

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -59,7 +59,7 @@
     <h2>Tiles</h2>
     <div class="tiles">
         {% for tile in ads.tiles %}
-        <a href="{{ tile.url }}" style="text-decoration: none; color: inherit;" target="_blank" >
+        <a href="{{ tile.url }}" target="_blank">
             <div class="tile">
                 <div class="tile-outer">
                     <img class="tile-image" src="{{ tile.image_url }}" alt="{{ tile.name }}"/>
@@ -77,7 +77,7 @@
     <h2>SPOCs</h2>
     <div class="spocs">
         {% for spoc in ads.spocs %}
-        <a href="{{ spoc.url }}" style="text-decoration: none; color: inherit;" target="_blank">
+        <a href="{{ spoc.url }}" target="_blank">
             <div class="spoc">
                 <img class="spoc-image" src="{{ spoc.image_src }}" alt="{{ spoc.title }}"/>
                 <div class="spoc-meta">


### PR DESCRIPTION
## References

JIRA: [AE-480](https://mozilla-hub.atlassian.net/browse/AE-480)

## Description

#209 caused a regression in how desktop SPOCs are displayed on the Shepherd Preview page. This fixes the styling for SPOCs such that they vertically expand to match the height of the tallest SPOC in the row.

Before:

![Screenshot 2024-07-19 at 10 48 04 AM](https://github.com/user-attachments/assets/d70ad490-f8c7-46fd-a8e6-7c9fb5ec4126)

After:

![Screenshot 2024-07-19 at 10 47 46 AM](https://github.com/user-attachments/assets/412d533a-a17f-437f-a551-54b36bb6ac39)

Also moves styling for links to CSS.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [ ] Functional and performance test coverage has been expanded and maintained (if applicable).

[AE-480]: https://mozilla-hub.atlassian.net/browse/AE-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ