### PR TITLE
[AE-479] fix shepherd preview page uses wrong field for direct sold tile titles

### DIFF
--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -242,7 +242,7 @@ def get_spocs_and_direct_sold_tiles(
     tiles = [
         Tile(
             image_url=create_image_url(tile["raw_image_src"], 48, 48),
-            name=tile["sponsor"],
+            name=tile["title"],
             url=tile["url"],
             sponsored=LOCALIZATIONS["Sponsored"][country],
         )

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -217,7 +217,7 @@ def get_spocs_and_direct_sold_tiles(
         spoc_site_id = env.spoc_site_id_mobile
 
     body = {
-        "pocket_id": f"{{{pocket_id}}}",  # produces "{uuid}"
+        "pocket_id": f"{{{pocket_id}}}",  # Produces "{uuid}"
         "site": spoc_site_id,
         "version": 2,
         "country": country,


### PR DESCRIPTION
## References

JIRA: [AE-479](https://mozilla-hub.atlassian.net/browse/AE-479)

## Description
Direct sold tiles were using the wrong field for the title display.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [ ] Functional and performance test coverage has been expanded and maintained (if applicable).

[AE-479]: https://mozilla-hub.atlassian.net/browse/AE-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ