### PR TITLE
Remove flake8 exceptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ black: $(INSTALL_STAMP)  ##  Run black
 
 .PHONY: flake8
 flake8: $(INSTALL_STAMP)  ##  Run flake8
-	$(POETRY) run flake8 $(APP_DIRS) --ignore=E203,E302,E501,E701
+	$(POETRY) run flake8 $(APP_DIRS) --max-line-length=120
 
 .PHONY: bandit
 bandit: $(INSTALL_STAMP)  ##  Run bandit

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -414,7 +414,10 @@ class PreviewView(TemplateView):
         env = find_env_by_code(env_code)
         agent = find_agent_by_code(agent_code)
 
-        debugMsg = f"{' &#x1F4F1; ' if agent.is_mobile else ''}country: {country}, region: {region}<br>env: {env}<br>{agent}"
+        mobileMsg = " &#x1F4F1; " if agent.is_mobile else ""
+        debugMsg = (
+            f"{mobileMsg}country: {country}, region: {region}<br>env: {env}<br>{agent}"
+        )
         try:
             ads = get_ads(env, country, region, agent)
             debugMsg += "<br>&#x2705;ok"


### PR DESCRIPTION
## Description

In #215 I noted I think we should stop ignoring PEP-8 conventions, but it might require changing a lot of files.

It turned out to be way easier than I expected, so this drops all ignored rules, except increasing the max line length to 120 characters (the default 79 characters is too short for modern screens, and we surpass it on >150 lines of code already).t

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [ ] Functional and performance test coverage has been expanded and maintained (if applicable).