### PR TITLE
Ad 456 update mars preview environment to allow the new regions via shepherd update

### DIFF
--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -39,7 +39,7 @@ LOCALIZATIONS = {
         "FR": "Sponsorisé par {sponsor}",
         "GB": "Sponsored by {sponsor}",
         "IT": "Sponsorizzata da {sponsor}",
-        "PL": "Sponsorowane przez {sponsor}",  # Temp translation from Google there was nothing in the FF ftl file
+        "PL": "Sponsor {sponsor}",
         "AT": "Werbung von {sponsor}",
         "NL": "Gesponsord door {sponsor}",
         "LU": "Sponsorisé par {sponsor}",

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -39,7 +39,7 @@ LOCALIZATIONS = {
         "FR": "Sponsorisé par {sponsor}",
         "GB": "Sponsored by {sponsor}",
         "IT": "Sponsorizzata da {sponsor}",
-        "PL": "Sponsor {sponsor}",
+        "PL": "Sponsor: {sponsor}",
         "AT": "Werbung von {sponsor}",
         "NL": "Gesponsord door {sponsor}",
         "LU": "Sponsorisé par {sponsor}",

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -39,7 +39,7 @@ LOCALIZATIONS = {
         "FR": "Sponsorisé par {sponsor}",
         "GB": "Sponsored by {sponsor}",
         "IT": "Sponsorizzata da {sponsor}",
-        "PL": "Sponsorowane przez {sponsor}", #Temp translation from Google since there was nothing in the FF ftl file for Polish
+        "PL": "Sponsorowane przez {sponsor}",  # Temp translation from Google there was nothing in the FF ftl file
         "AT": "Werbung von {sponsor}",
         "NL": "Gesponsord door {sponsor}",
         "LU": "Sponsorisé par {sponsor}",
@@ -195,7 +195,7 @@ COUNTRIES: list[Region] = [
     Region(code="NL", name="Netherlands"),
     Region(code="LU", name="Luxembourg"),
     Region(code="CH", name="Switzerland"),
-    Region(code="BE", name="Belgium"), 
+    Region(code="BE", name="Belgium"),
 ]
 
 

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -24,6 +24,12 @@ LOCALIZATIONS = {
         "FR": "Sponsorisé",
         "GB": "Sponsored",
         "IT": "Sponsorizzato",
+        "PL": "Sponsorowane",
+        "AT": "Gesponsert",
+        "NL": "Gesponsord",
+        "LU": "Sponsorisé",
+        "CH": "Gesponsert",
+        "BE": "Gesponsord",
     },
     "Sponsored by": {
         "US": "Sponsored by {sponsor}",
@@ -33,6 +39,12 @@ LOCALIZATIONS = {
         "FR": "Sponsorisé par {sponsor}",
         "GB": "Sponsored by {sponsor}",
         "IT": "Sponsorizzata da {sponsor}",
+        "PL": "Sponsorowane przez {sponsor}", #Temp translation from Google since there was nothing in the FF ftl file for Polish
+        "AT": "Werbung von {sponsor}",
+        "NL": "Gesponsord door {sponsor}",
+        "LU": "Sponsorisé par {sponsor}",
+        "CH": "Werbung von {sponsor}",
+        "BE": "Gesponsord door {sponsor}",
     },
 }
 
@@ -178,6 +190,12 @@ COUNTRIES: list[Region] = [
     Region(code="FR", name="France"),
     Region(code="GB", name="United Kingdom"),
     Region(code="IT", name="Italy"),
+    Region(code="PL", name="Poland"),
+    Region(code="AT", name="Austria"),
+    Region(code="NL", name="Netherlands"),
+    Region(code="LU", name="Luxembourg"),
+    Region(code="CH", name="Switzerland"),
+    Region(code="BE", name="Belgium"), 
 ]
 
 

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -48,9 +48,12 @@ STATSD_PREFIX = env("STATSD_PREFIX", default="shepherd")
 # See: https://pypi.org/project/django-countries/#customization
 # Contile advertisers list. Simply add the ISO 3166-1 country code to add as option.
 COUNTRIES_ONLY: list[str] = [
+    "AT",
     "AU",
+    "BE",
     "BR",
     "CA",
+    "CH",
     "DE",
     "ES",
     "FR",
@@ -58,7 +61,10 @@ COUNTRIES_ONLY: list[str] = [
     "IN",
     "IT",
     "JP",
+    "LU",
     "MX",
+    "NL",
+    "PL", 
     "US",
 ]
 COUNTRIES_FIRST_SORT: bool = True

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -64,7 +64,7 @@ COUNTRIES_ONLY: list[str] = [
     "LU",
     "MX",
     "NL",
-    "PL", 
+    "PL",
     "US",
 ]
 COUNTRIES_FIRST_SORT: bool = True


### PR DESCRIPTION
## References

JIRA: [AD--456 Update MARS preview environment to allow the new regions via shepherd updte](https://mozilla-hub.atlassian.net/browse/AD-456)

## Description
Launching a test of Sponsored Tiles on desktop into 6 new EU markets (Poland, Austria, Netherlands, Luxembourg, Switzerland and Belgium). This update makes it easy to preview the tiles using the MARS Ads Preview Tool.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [] Functional and performance test coverage has been expanded and maintained (if applicable).