### PR TITLE
Use Form Factor instead of User Agent in Preview UI

### DIFF
--- a/consvc_shepherd/tests/test_preview.py
+++ b/consvc_shepherd/tests/test_preview.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 from django.test import TestCase, override_settings
 
-from consvc_shepherd.preview import Agent, Environment, Spoc, Tile, get_ads
+from consvc_shepherd.preview import Environment, FormFactor, Spoc, Tile, get_ads
 
 SPOC = Spoc(
     image_src="https://picsum.photos/296/148",
@@ -71,19 +71,20 @@ class TestGetAds(TestCase):
                     spoc_zone_ids=[],
                     direct_sold_tile_zone_ids=[424242],
                 )
-                mockAgent = Agent(
-                    code="Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0",
+                mockFormFactor = FormFactor(
+                    code="desktop",
                     name="Desktop",
                     is_mobile=False,
+                    user_agent="Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0",
                 )
-                ads = get_ads(mockEnv, "US", "CA", mockAgent)
+                ads = get_ads(mockEnv, "US", "CA", mockFormFactor)
 
                 # Function calls
                 mock_get_amp_tiles.assert_called_once_with(
-                    mockEnv, "US", "CA", mockAgent.code
+                    mockEnv, "US", "CA", mockFormFactor.user_agent
                 )
                 mock_get_spocs_and_direct_sold_tiles.assert_called_once_with(
-                    mockEnv, "US", "CA", mockAgent.is_mobile
+                    mockEnv, "US", "CA", mockFormFactor.is_mobile
                 )
                 self.assertEqual(len(ads.spocs), 1)
                 self.assertEqual(len(ads.tiles), 3)

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -22,13 +22,13 @@
         </select>
 
         <br/><br/>
-        <label for="agent">User Agent </label>&nbsp;
-        <select name="agent" id="agent" style="text-overflow: ellipsis;width: 200px;">
-            {% for anAgent in agents %}
-                {% if anAgent.code == agent %}
-                    <option value="{{ anAgent.code }}" selected="selected">{{ anAgent.name }}</option>
+        <label for="form_factor">Form Factor</label>&nbsp;
+        <select name="form_factor" id="form_factor">
+            {% for aFormFactor in form_factors %}
+                {% if aFormFactor.code == form_factor %}
+                    <option value="{{ aFormFactor.code }}" selected="selected">{{ aFormFactor.name }}</option>
                 {% else %}
-                    <option value="{{ anAgent.code }}">{{ anAgent.name }}</option>
+                    <option value="{{ aFormFactor.code }}">{{ aFormFactor.name }}</option>
                 {% endif %}
             {% endfor %}
         </select>


### PR DESCRIPTION
## Description

The use of "User Agent" on the preview page is an unnecessary implementation detail. Replace this with a more friendly "Form Factor" instead.

Also use shorter slugs for form factors (desktop, mobile) instead of passing the entire UA string in the query parameter.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [ ] Functional and performance test coverage has been expanded and maintained (if applicable).