### PR TITLE
[AE-532] Add upper limit to boostr deals fetching

### DIFF
--- a/consvc_shepherd/management/commands/sync_boostr_data.py
+++ b/consvc_shepherd/management/commands/sync_boostr_data.py
@@ -8,6 +8,8 @@ from django.core.management.base import BaseCommand
 
 from consvc_shepherd.models import BoostrDeal, BoostrDealProduct, BoostrProduct
 
+MAX_DEAL_PAGES_DEFAULT = 50
+
 
 class Command(BaseCommand):
     """Django admin custom command for fetching and saving Deal and Product data from Boostr to Shepherd"""
@@ -31,11 +33,22 @@ class Command(BaseCommand):
             type=str,
             help="The password for the Boostr API account (see 1password Ads Eng vault)",
         )
+        parser.add_argument(
+            "--max-deal-pages",
+            default=MAX_DEAL_PAGES_DEFAULT,
+            type=int,
+            help=f"""By default, the sync code will stop trying to fetch additional deals pages after
+                {MAX_DEAL_PAGES_DEFAULT} pages. Currently we have ~14 pages of deals in Boostr, so this default max
+                should be sufficient for a while.""",
+        )
 
     def handle(self, *args, **options):
         """Handle running the command"""
         loader = BoostrLoader(
-            options["base_url"], options["email"], options["password"]
+            options["base_url"],
+            options["email"],
+            options["password"],
+            options["max_deal_pages"],
         )
         loader.load()
 
@@ -52,10 +65,18 @@ class BoostrLoader:
     base_url: str
     session: requests.Session
     log: logging.Logger
+    max_deal_pages: int
 
-    def __init__(self, base_url: str, email: str, password: str):
+    def __init__(
+        self,
+        base_url: str,
+        email: str,
+        password: str,
+        max_deal_pages=MAX_DEAL_PAGES_DEFAULT,
+    ):
         self.log = logging.getLogger("sync_boostr_data")
         self.base_url = base_url
+        self.max_deal_pages = max_deal_pages
         self.setup_session(email, password)
 
     def setup_session(self, email: str, password: str) -> None:
@@ -118,10 +139,9 @@ class BoostrLoader:
             "page": str(page),
             "filter": "all",
         }
-        while True:
+        while page < self.max_deal_pages:
             page += 1
             deals_params["page"] = str(page)
-
             deals_response = self.session.get(
                 f"{self.base_url}/deals", params=deals_params
             )
@@ -155,6 +175,11 @@ class BoostrLoader:
 
                 self.upsert_deal_products(boostr_deal)
                 self.log.info(f"Upserted products and budgets for deal: {deal['id']}")
+            # If this is the last iteration of the loop due to the max page limit, log that we stopped
+            if page >= self.max_deal_pages:
+                self.log.info(
+                    f"Done. Stopped fetching deals after hitting max_page_limit of {page} pages."
+                )
 
     def upsert_deal_products(self, deal: BoostrDeal) -> None:
         """Fetch the deal_products for a particular deal and store them in our DB with their monthly budgets"""

--- a/consvc_shepherd/tests/test_sync_boostr.py
+++ b/consvc_shepherd/tests/test_sync_boostr.py
@@ -476,6 +476,21 @@ class TestSyncBoostrData(TestCase):
     @mock.patch("requests.post", side_effect=mock_post_success)
     @mock.patch.object(requests.Session, "get", side_effect=mock_get_success)
     @mock.patch(
+        "consvc_shepherd.models.BoostrDeal.objects.update_or_create",
+        side_effect=mock_update_or_create_deal,
+    )
+    @mock.patch.object(BoostrLoader, "upsert_deal_products")
+    def test_upsert_deals_respects_max_deal_pages_limit(
+        self, mock_upsert_deal_products, mock_update_or_create, mock_get, mock_post
+    ):
+        """Test that upsert_deals respects the max_deal_pages limit"""
+        loader = BoostrLoader(BASE_URL, EMAIL, PASSWORD, 3)
+        loader.upsert_deals()
+        assert 3 == mock_get.call_count
+
+    @mock.patch("requests.post", side_effect=mock_post_success)
+    @mock.patch.object(requests.Session, "get", side_effect=mock_get_success)
+    @mock.patch(
         "consvc_shepherd.models.BoostrProduct.objects.get", side_effect=mock_get_product
     )
     @mock.patch("consvc_shepherd.models.BoostrDealProduct.objects.update_or_create")

--- a/consvc_shepherd/tests/test_sync_boostr.py
+++ b/consvc_shepherd/tests/test_sync_boostr.py
@@ -483,10 +483,25 @@ class TestSyncBoostrData(TestCase):
     def test_upsert_deals_respects_max_deal_pages_limit(
         self, mock_upsert_deal_products, mock_update_or_create, mock_get, mock_post
     ):
-        """Test that upsert_deals respects the max_deal_pages limit"""
+        """Test that upsert_deals respects the given max_deal_pages limit"""
         loader = BoostrLoader(BASE_URL, EMAIL, PASSWORD, 3)
         loader.upsert_deals()
         assert 3 == mock_get.call_count
+
+    @mock.patch("requests.post", side_effect=mock_post_success)
+    @mock.patch.object(requests.Session, "get", side_effect=mock_get_success)
+    @mock.patch(
+        "consvc_shepherd.models.BoostrDeal.objects.update_or_create",
+        side_effect=mock_update_or_create_deal,
+    )
+    @mock.patch.object(BoostrLoader, "upsert_deal_products")
+    def test_upsert_deals_respects_default_max_deal_pages_limit(
+        self, mock_upsert_deal_products, mock_update_or_create, mock_get, mock_post
+    ):
+        """Test that upsert_deals respects the default max_deal_pages limit"""
+        loader = BoostrLoader(BASE_URL, EMAIL, PASSWORD)
+        loader.upsert_deals()
+        assert 50 == mock_get.call_count
 
     @mock.patch("requests.post", side_effect=mock_post_success)
     @mock.patch.object(requests.Session, "get", side_effect=mock_get_success)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Create and Publish Snapshots](./operations/createPublishSnapshots.md)
   - [Rollback](./operations/rollback.md)
   - [Recover Snapshot](./operations/recoveryScript.md)
+  - [Sync Data from Boostr](./operations/syncBoostrData.md)
 
 
 # ADR

--- a/docs/operations/syncBoostrData.md
+++ b/docs/operations/syncBoostrData.md
@@ -16,9 +16,30 @@ docker exec -it consvc-shepherd-app-1 sh
 python manage.py sync_boostr_data https://app.boostr.com/api/ find-me-in-1pass@mozilla.com find-me-in-1pass
 ```
 
-### Notes
+### Optional arguments
 
-The script takes several minutes to run. To get more detailed logging on which specific deals and products are being saved, run with `SHEPHERD_ENV=DEBUG`
+The script can take an optional named argument, `--max-deal-pages`, which will
+set an upper limit on the number of pages of deals that we fetch from the API.
+
+By default, the script will fetch pages of 300 deals at a time until it
+receives an empty response from the Boostr API. And if it never receives an
+empty response, the script will stop fetching after 50 deal pages by default
+(`MAX_DEAL_PAGES_DEFAULT`).
+
+We currently have about 14 pages of deals (at 300 deals per page) in our
+production Boostr account, so the default value of 50 gives us lots of overhead,
+but this parameter allows us to invoke the script with a custom value for the
+upper limit on deal pages.
+
+Usage:
+```sh
+SHEPHERD_ENV=DEBUG python manage.py sync_boostr_data https://app.boostr.com/api/ find-me-in-1pass@mozilla.com find-me-in-1pass --max-deal-pages 42
+```
+
+### Debug logs
+
+The script takes several minutes to run. To get more detailed logging on which
+specific deals and products are being saved, run with `SHEPHERD_ENV=DEBUG`
 
 ```shell
 SHEPHERD_ENV=DEBUG python manage.py sync_boostr_data https://app.boostr.com/api/ find-me-in-1pass@mozilla.com find-me-in-1pass

--- a/docs/operations/syncBoostrData.md
+++ b/docs/operations/syncBoostrData.md
@@ -1,4 +1,4 @@
-## Sync data from Boostr and upsert it into the Shepherd DB
+# Sync data from Boostr and upsert it into the Shepherd DB
 
 Currently this is a Django admin command that can be manually run by `docker exec`-ing into a shepherd app container. The intention is that this will become a regularly running job soon.
 


### PR DESCRIPTION
## References

JIRA: [AE-532](https://mozilla-hub.atlassian.net/browse/AE-532)

@cbguder [made a good point](https://github.com/mozilla-services/consvc-shepherd/pull/215#discussion_r1702065723) on the last iteration of the Boostr sync script, that the `while True` loop is dangerous and might not ever finish if we receive something unexpected back from the API.

This change addresses that by adding an upper limit of how many times we fetch deals pages. It is set up for a default max of `50`, and can be adjusted by passing an optional parameter to the script.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [x] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [x] Functional and performance test coverage has been expanded and maintained (if applicable).

[AE-532]: https://mozilla-hub.atlassian.net/browse/AE-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ