### PR TITLE
[AE-535] Add unit tests for get_amp_tiles and get_spocs_and_direct_sold_tiles functions

### DIFF
--- a/consvc_shepherd/tests/test_preview.py
+++ b/consvc_shepherd/tests/test_preview.py
@@ -180,7 +180,7 @@ class TestGetSpocsAndDirectSoldTiles(TestCase):
         country: str,
         region: str,
         is_mobile: bool,
-        expected_site_id: int,
+        expected_site_id: int | None,
     ):
         with mock.patch(
             "requests.post",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,3 @@ add-ignore = ["D105","D107","D203", "D205", "D400"]
 # '^(?!migrations).*' ignores all Django-generated migration files
 match-dir = '^(?!migrations).*'
 
-[tool.coverage.run]
-omit = [
-    "consvc_shepherd/preview.py"
-]


### PR DESCRIPTION
## References

JIRA: [AE-535](https://mozilla-hub.atlassian.net/browse/AE-535)

## Description

This PR adds unit tests for the `get_amp_tiles` and `get_spocs_and_direct_sold_tiles` functions. The goal is to ensure that we correctly extract the expected keys and values from their responses and use them as intended in our views.


## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [x] Functional and performance test coverage has been expanded and maintained (if applicable).

[AE-535]: https://mozilla-hub.atlassian.net/browse/AE-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ