### PR TITLE
[AE-534] Respect the rate limits

### DIFF
--- a/consvc_shepherd/management/commands/sync_boostr_data.py
+++ b/consvc_shepherd/management/commands/sync_boostr_data.py
@@ -2,6 +2,7 @@
 
 import logging
 import math
+from time import sleep
 from typing import Any
 
 import requests
@@ -10,6 +11,7 @@ from django.core.management.base import BaseCommand
 from consvc_shepherd.models import BoostrDeal, BoostrDealProduct, BoostrProduct
 
 MAX_DEAL_PAGES_DEFAULT = 50
+RATE_LIMIT_REQUEST_INTERVAL_SECS = 0.7
 
 
 class Command(BaseCommand):
@@ -92,6 +94,7 @@ class BoostrApi:
         """Make POST requests to Boostr that uses the session, pass through headers and json data,
         check status, and return parsed json
         """
+        sleep(RATE_LIMIT_REQUEST_INTERVAL_SECS)
         response = self.session.post(
             f"{self.base_url}/{path}",
             json=json,
@@ -109,6 +112,7 @@ class BoostrApi:
         """Make GET requests to Boostr that use the session, pass through headers and query params,
         check status, and return parsed json
         """
+        sleep(RATE_LIMIT_REQUEST_INTERVAL_SECS)
         response = self.session.get(
             f"{self.base_url}/{path}", params=params, headers=headers, timeout=15
         )

--- a/consvc_shepherd/management/commands/sync_boostr_data.py
+++ b/consvc_shepherd/management/commands/sync_boostr_data.py
@@ -2,6 +2,7 @@
 
 import logging
 import math
+from typing import Any
 
 import requests
 from django.core.management.base import BaseCommand
@@ -59,24 +60,14 @@ class BoostrApiError(Exception):
     pass
 
 
-class BoostrLoader:
-    """Wrap up interaction with the Boostr API"""
+class BoostrApi:
+    """Wrap up interactions with the Boostr API into a convenient class that handles the session, rate limits, etc"""
 
     base_url: str
     session: requests.Session
-    log: logging.Logger
-    max_deal_pages: int
 
-    def __init__(
-        self,
-        base_url: str,
-        email: str,
-        password: str,
-        max_deal_pages=MAX_DEAL_PAGES_DEFAULT,
-    ):
-        self.log = logging.getLogger("sync_boostr_data")
+    def __init__(self, base_url: str, email: str, password: str):
         self.base_url = base_url
-        self.max_deal_pages = max_deal_pages
         self.setup_session(email, password)
 
     def setup_session(self, email: str, password: str) -> None:
@@ -85,26 +76,61 @@ class BoostrLoader:
             "Accept": "application/vnd.boostr.public",
             "Content-Type": "application/json",
         }
-        token = self.authenticate(email, password, headers)
+        self.session = requests.Session()
+        self.session.headers.update(headers)
+        token = self.authenticate(email, password)
         headers["Authorization"] = f"Bearer {token}"
-        s = requests.Session()
-        s.headers.update(headers)
-        self.session = s
+        self.session.headers.update(headers)
 
-    def authenticate(self, email: str, password: str, headers: dict[str, str]) -> str:
+    def authenticate(self, email: str, password: str) -> str:
         """Authenticate with the Boostr API and return jwt"""
-        user_token_response = requests.post(
-            f"{self.base_url}/user_token",
-            json={"auth": {"email": email, "password": password}},
+        post_data = {"auth": {"email": email, "password": password}}
+        token = self.post("user_token", post_data)
+        return str(token["jwt"])
+
+    def post(self, path: str, json={}, headers={}) -> Any:
+        """Make POST requests to Boostr that uses the session, pass through headers and json data,
+        check status, and return parsed json
+        """
+        response = self.session.post(
+            f"{self.base_url}/{path}",
+            json=json,
             headers=headers,
             timeout=15,
         )
-        if user_token_response.status_code != 201:
+        if not response.ok:
             raise BoostrApiError(
-                f"Bad response status from /api/user_token: {user_token_response}"
+                f"Bad response status {response.status_code} from /{path}: {response}"
             )
-        token = user_token_response.json()
-        return str(token["jwt"])
+        json = response.json()
+        return json
+
+    def get(self, path: str, params={}, headers={}):
+        """Make GET requests to Boostr that use the session, pass through headers and query params,
+        check status, and return parsed json
+        """
+        response = self.session.get(
+            f"{self.base_url}/{path}", params=params, headers=headers, timeout=15
+        )
+        if not response.ok:
+            raise BoostrApiError(
+                f"Bad response status {response.status_code} from /{path}: {response}"
+            )
+        json = response.json()
+        return json
+
+
+class BoostrLoader:
+    """Wrap up interaction with the Boostr API"""
+
+    boostr: BoostrApi
+    log: logging.Logger
+    max_deal_pages: int
+
+    def __init__(self, base_url: str, email: str, password: str, max_deal_pages=50):
+        self.log = logging.getLogger("sync_boostr_data")
+        self.boostr = BoostrApi(base_url, email, password)
+        self.max_deal_pages = max_deal_pages
 
     def upsert_products(self) -> None:
         """Fetch all Boostr products and upsert them to Shepherd DB"""
@@ -113,14 +139,7 @@ class BoostrLoader:
             "page": "1",
             "filter": "all",
         }
-        products_response = self.session.get(
-            f"{self.base_url}/products", params=products_params
-        )
-        if products_response.status_code != 200:
-            raise BoostrApiError(
-                f"Bad response status from /api/products: {products_response}"
-            )
-        products = products_response.json()
+        products = self.boostr.get("products", params=products_params)
         self.log.info(f"Fetched {(len(products))} products")
 
         for product in products:
@@ -142,14 +161,8 @@ class BoostrLoader:
         while page < self.max_deal_pages:
             page += 1
             deals_params["page"] = str(page)
-            deals_response = self.session.get(
-                f"{self.base_url}/deals", params=deals_params
-            )
-            if deals_response.status_code != 200:
-                raise BoostrApiError(
-                    f"Bad response status from /api/deals: {deals_response}"
-                )
-            deals = deals_response.json()
+
+            deals = self.boostr.get("deals", params=deals_params)
             self.log.info(f"Fetched {len(deals)} deals for page {page}")
 
             # Paged through all available records and are getting an empty list back
@@ -183,16 +196,8 @@ class BoostrLoader:
 
     def upsert_deal_products(self, deal: BoostrDeal) -> None:
         """Fetch the deal_products for a particular deal and store them in our DB with their monthly budgets"""
-        deal_products_response = self.session.get(
-            f"{self.base_url}/deals/{deal.boostr_id}/deal_products"
-        )
+        deal_products = self.boostr.get(f"deals/{deal.boostr_id}/deal_products")
 
-        if deal_products_response.status_code != 200:
-            raise BoostrApiError(
-                f"Bad response status from /api/deals/{deal.boostr_id}/deal_products: {deal_products_response}"
-            )
-
-        deal_products = deal_products_response.json()
         self.log.debug(
             f"Fetched {len(deal_products)} deal_products for deal: {deal.boostr_id}"
         )

--- a/consvc_shepherd/tests/test_sync_boostr.py
+++ b/consvc_shepherd/tests/test_sync_boostr.py
@@ -28,9 +28,12 @@ class MockResponse:
         return self.json_data
 
 
-def mock_post_token_success(*args, **kwargs) -> MockResponse:
-    """Mock successful POST /user_token requests to boostr"""
-    return MockResponse({"jwt": "i.am.jwt"}, 201)
+def mock_post_success(*args, **kwargs) -> MockResponse:
+    """Mock successful POST requests to boostr"""
+    if args[0].endswith("/user_token"):
+        return MockResponse({"jwt": "i.am.jwt"}, 201)
+    else:
+        return MockResponse({"data": "wow", "count": 42}, 200)
 
 
 def mock_post_token_fail(*args, **kwargs) -> MockResponse:
@@ -370,8 +373,9 @@ PASSWORD = "test"  # nosec
 class TestSyncBoostrData(TestCase):
     """Unit tests for functions that fetch from boostr API and store in our DB"""
 
+    @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
     @mock.patch.object(BoostrApi, "authenticate", return_value="im.a.jwt")
-    def test_setup_session(self, mock_authenticate):
+    def test_setup_session(self, mock_sleep, mock_authenticate):
         """Test the function that sets up the headers, authenticates with boosrt, and sets up the session"""
         boostr = BoostrApi(BASE_URL, EMAIL, PASSWORD)
         self.assertEqual(
@@ -380,23 +384,28 @@ class TestSyncBoostrData(TestCase):
         self.assertEqual(boostr.session.headers["Content-Type"], "application/json")
         self.assertEqual(boostr.session.headers["Authorization"], "Bearer im.a.jwt")
 
-    @mock.patch("requests.Session.post", side_effect=mock_post_token_success)
-    def test_authenticate(self, mock_post):
+    @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
+    @mock.patch("requests.Session.post", side_effect=mock_post_success)
+    def test_authenticate(self, mock_sleep, mock_post):
         """Test authenticate function that calls boostr auth and returns a JWT"""
         boostr = BoostrApi(BASE_URL, EMAIL, PASSWORD)
         jwt = boostr.authenticate(EMAIL, PASSWORD)
         self.assertEqual(jwt, "i.am.jwt")
 
+    @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
     @mock.patch("requests.Session.post", side_effect=mock_post_token_fail)
-    def test_authenticate_fail(self, mock_post):
+    def test_authenticate_fail(self, mock_post, mock_sleep):
         """Test sad path for the authenticate function"""
         with self.assertRaises(BoostrApiError):
-            BoostrApi("https://fail_url.lol", "uhoh@mozilla.com", "uhoh")
+            BoostrApi("fail/lol", "uhoh@mozilla.com", "uhoh")
 
-    @mock.patch("requests.Session.post", side_effect=mock_post_token_success)
+    @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
+    @mock.patch("requests.Session.post", side_effect=mock_post_success)
     @mock.patch("requests.Session.get", side_effect=mock_get_success)
     @mock.patch("consvc_shepherd.models.BoostrProduct.objects.update_or_create")
-    def test_upsert_products(self, mock_update_or_create, mock_get, mock_post):
+    def test_upsert_products(
+        self, mock_update_or_create, mock_get, mock_post, mock_sleep
+    ):
         """Test function that calls boostr API for product data and saves to our DB"""
         loader = BoostrLoader(BASE_URL, EMAIL, PASSWORD)
         loader.upsert_products()
@@ -414,15 +423,17 @@ class TestSyncBoostrData(TestCase):
         ]
         mock_update_or_create.assert_has_calls(calls)
 
-    @mock.patch("requests.Session.post", side_effect=mock_post_token_success)
+    @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
+    @mock.patch("requests.Session.post", side_effect=mock_post_success)
     @mock.patch("requests.Session.get", side_effect=mock_get_fail)
-    def test_upsert_products_fail(self, mock_get, mock_post):
+    def test_upsert_products_fail(self, mock_get, mock_post, mock_sleep):
         """Test that upsert_products will raise an API error on non-200 status"""
         loader = BoostrLoader(BASE_URL, EMAIL, PASSWORD)
         with self.assertRaises(BoostrApiError):
             loader.upsert_products()
 
-    @mock.patch("requests.Session.post", side_effect=mock_post_token_success)
+    @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
+    @mock.patch("requests.Session.post", side_effect=mock_post_success)
     @mock.patch("requests.Session.get", side_effect=mock_get_success)
     @mock.patch(
         "consvc_shepherd.models.BoostrDeal.objects.update_or_create",
@@ -430,7 +441,12 @@ class TestSyncBoostrData(TestCase):
     )
     @mock.patch.object(BoostrLoader, "upsert_deal_products")
     def test_upsert_deals(
-        self, mock_upsert_deal_products, mock_update_or_create, mock_get, mock_post
+        self,
+        mock_upsert_deal_products,
+        mock_update_or_create,
+        mock_get,
+        mock_post,
+        mock_sleep,
     ):
         """Test function that calls the Boostr API for deal data and saves to our DB"""
         self.skipTest(
@@ -462,15 +478,17 @@ class TestSyncBoostrData(TestCase):
         ]
         mock_update_or_create.assert_has_calls(calls)
 
-    @mock.patch("requests.Session.post", side_effect=mock_post_token_success)
+    @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
+    @mock.patch("requests.Session.post", side_effect=mock_post_success)
     @mock.patch("requests.Session.get", side_effect=mock_get_fail)
-    def test_upsert_deals_fail(self, mock_get, mock_post):
+    def test_upsert_deals_fail(self, mock_get, mock_post, mock_sleep):
         """Test that upsert_deals will raise an API error on non-200 status"""
         loader = BoostrLoader(BASE_URL, EMAIL, PASSWORD)
         with self.assertRaises(BoostrApiError):
             loader.upsert_deals()
 
-    @mock.patch("requests.Session.post", side_effect=mock_post_token_success)
+    @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
+    @mock.patch("requests.Session.post", side_effect=mock_post_success)
     @mock.patch("requests.Session.get", side_effect=mock_get_success)
     @mock.patch(
         "consvc_shepherd.models.BoostrDeal.objects.update_or_create",
@@ -478,14 +496,20 @@ class TestSyncBoostrData(TestCase):
     )
     @mock.patch.object(BoostrLoader, "upsert_deal_products")
     def test_upsert_deals_respects_max_deal_pages_limit(
-        self, mock_upsert_deal_products, mock_update_or_create, mock_get, mock_post
+        self,
+        mock_upsert_deal_products,
+        mock_update_or_create,
+        mock_get,
+        mock_post,
+        mock_sleep,
     ):
         """Test that upsert_deals respects the given max_deal_pages limit"""
         loader = BoostrLoader(BASE_URL, EMAIL, PASSWORD, 3)
         loader.upsert_deals()
         assert 3 == mock_get.call_count
 
-    @mock.patch("requests.Session.post", side_effect=mock_post_token_success)
+    @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
+    @mock.patch("requests.Session.post", side_effect=mock_post_success)
     @mock.patch("requests.Session.get", side_effect=mock_get_success)
     @mock.patch(
         "consvc_shepherd.models.BoostrDeal.objects.update_or_create",
@@ -493,21 +517,27 @@ class TestSyncBoostrData(TestCase):
     )
     @mock.patch.object(BoostrLoader, "upsert_deal_products")
     def test_upsert_deals_respects_default_max_deal_pages_limit(
-        self, mock_upsert_deal_products, mock_update_or_create, mock_get, mock_post
+        self,
+        mock_upsert_deal_products,
+        mock_update_or_create,
+        mock_get,
+        mock_post,
+        mock_sleep,
     ):
         """Test that upsert_deals respects the default max_deal_pages limit"""
         loader = BoostrLoader(BASE_URL, EMAIL, PASSWORD)
         loader.upsert_deals()
         assert 50 == mock_get.call_count
 
-    @mock.patch("requests.Session.post", side_effect=mock_post_token_success)
+    @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
+    @mock.patch("requests.Session.post", side_effect=mock_post_success)
     @mock.patch("requests.Session.get", side_effect=mock_get_success)
     @mock.patch(
         "consvc_shepherd.models.BoostrProduct.objects.get", side_effect=mock_get_product
     )
     @mock.patch("consvc_shepherd.models.BoostrDealProduct.objects.update_or_create")
     def test_upsert_deal_products(
-        self, mock_update_or_create, mock_get_product, mock_get, mock_post
+        self, mock_update_or_create, mock_get_product, mock_get, mock_post, mock_sleep
     ):
         """Test function that fetches the products per month and their budget for a particular deal"""
         deal = BoostrDeal(
@@ -562,9 +592,10 @@ class TestSyncBoostrData(TestCase):
         ]
         mock_update_or_create.assert_has_calls(calls)
 
-    @mock.patch("requests.Session.post", side_effect=mock_post_token_success)
+    @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
+    @mock.patch("requests.Session.post", side_effect=mock_post_success)
     @mock.patch("requests.Session.get", side_effect=mock_get_fail)
-    def test_upsert_deal_products_fail(self, mock_get, mock_post):
+    def test_upsert_deal_products_fail(self, mock_get, mock_post, mock_sleep):
         """Test that upsert_deal_products will raise an API error on non-200 status"""
         deal = BoostrDeal(
             boostr_id=123456,
@@ -597,3 +628,58 @@ class TestSyncBoostrData(TestCase):
         self.assertEqual(
             get_campaign_type(no_campaign_type_name), BoostrProduct.CampaignType.NONE
         )
+
+    @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
+    @mock.patch("requests.Session.post", side_effect=mock_post_success)
+    def test_boostr_api_post(self, mock_post_success, mock_sleep):
+        """Test the BoostrApi POST wrapper"""
+        boostr = BoostrApi(BASE_URL, EMAIL, PASSWORD)
+        auth_json = {"auth": {"email": "email@mozilla.com", "password": "test"}}
+        post_json = {"info": "for the server"}
+        headers = {"X-Boostr-Whatever": "Stuff"}
+        response = boostr.post("some-path", json=post_json, headers=headers)
+        calls = [
+            mock.call(
+                f"{BASE_URL}/user_token",
+                json=auth_json,
+                headers={},
+                timeout=15,
+            ),
+            mock.call(
+                f"{BASE_URL}/some-path",
+                json=post_json,
+                headers=headers,
+                timeout=15,
+            ),
+        ]
+        self.assertEqual(response["data"], "wow")
+        self.assertEqual(response["count"], 42)
+        mock_post_success.assert_has_calls(calls)
+        self.assertEqual(mock_sleep.call_count, len(calls))
+
+    @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
+    @mock.patch("requests.Session.post", side_effect=mock_post_success)
+    @mock.patch("requests.Session.get", side_effect=mock_get_success)
+    def test_boostr_api_get(self, mock_get_success, mock_post_success, mock_sleep):
+        """Test the BoostrApi GET wrapper"""
+        boostr = BoostrApi(BASE_URL, EMAIL, PASSWORD)
+        headers = {"X-Boostr-Whatever": "Stuff"}
+        products_params = {
+            "per": "300",
+            "page": "1",
+            "filter": "all",
+        }
+        products = boostr.get("products", headers=headers, params=products_params)
+        calls = [
+            mock.call(
+                f"{BASE_URL}/products",
+                params=products_params,
+                headers=headers,
+                timeout=15,
+            ),
+        ]
+        self.assertEqual(len(products), 2)
+        mock_get_success.assert_has_calls(calls)
+        self.assertEqual(
+            mock_sleep.call_count, 2
+        )  # once for the POST /user_token under the hood, once for GET /products


### PR DESCRIPTION
## References

JIRA: [AE-534](https://mozilla-hub.atlassian.net/browse/AE-534)

## Description
Recently, Boostr surprised us by [introducing rate limits to the API](https://help.boostr.com/en/articles/9006378-public-api-rate-limits-and-best-practices). This simple change:

- Refactors the script to have a wrapper for Boostr Api requests
- Slows down requests by an interval that's just slower than what the Boostr rate limit allows. This keeps us under their rate limits and not needing to handle 429s, but we can add that in a subsequent PR if it becomes necessary

I'm thinking this will unlock the ability to run the script in all environments when @cyptm's scheduled job changes land, even though it runs slower, that should be fine.

Longer term, we can look at other ways to limit the amount of data we are pulling by creating a real staging environment (AE-501) and by further enhancing the script to only pull what has changed since the last time (no ticket yet as it would be an enhancement and we likely have bigger fish to fry)

To verify this change locally, run the script and see that it chugs along slowly but surely staying under the rate limits and not receiving 429s. I'll do more local testing as well. 

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[AE-534]]`, and has the same title (if applicable).
- [x] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [x] Functional and performance test coverage has been expanded and maintained (if applicable).

[AE-534]: https://mozilla-hub.atlassian.net/browse/AE-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AE-534]: https://mozilla-hub.atlassian.net/browse/AE-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ