### PR TITLE
Update sync_boostr_data usage documentation

### DIFF
--- a/docs/operations/syncBoostrData.md
+++ b/docs/operations/syncBoostrData.md
@@ -14,7 +14,7 @@ docker exec -it consvc-shepherd-app-1 sh
 4. Find the base url of the Boostr API that you want to hit. For production Boostr, this is "https://app.boostr.com/api/".
 5. Run the script, providing base url as a positional arg.
 ```sh
-python manage.py sync_boostr_data https://app.boostr.com/api/ find-me-in-1pass@mozilla.com find-me-in-1pass
+python manage.py sync_boostr_data https://app.boostr.com/api/
 ```
 
 ### Optional arguments
@@ -34,7 +34,7 @@ upper limit on deal pages.
 
 Usage:
 ```sh
-SHEPHERD_ENV=DEBUG python manage.py sync_boostr_data https://app.boostr.com/api/ find-me-in-1pass@mozilla.com find-me-in-1pass --max-deal-pages 42
+python manage.py sync_boostr_data
 ```
 
 ### Debug logs
@@ -43,5 +43,5 @@ The script takes several minutes to run. To get more detailed logging on which
 specific deals and products are being saved, run with `SHEPHERD_ENV=DEBUG`
 
 ```shell
-SHEPHERD_ENV=DEBUG python manage.py sync_boostr_data https://app.boostr.com/api/ find-me-in-1pass@mozilla.com find-me-in-1pass
+SHEPHERD_ENV=DEBUG python manage.py sync_boostr_data
 ```


### PR DESCRIPTION
We missed some `README` updates for the way the boostr sync script accepts the API credentials, so just adding them now. 

Reviewer, please take a look over the sync script docs and make sure I haven't missed anything else.

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [-] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [x] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [-] Functional and performance test coverage has been expanded and maintained (if applicable).