### PR TITLE
[AE-519] Rename user_context_id to context_id

### DIFF
--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -317,7 +317,7 @@ def get_amp_tiles(
 
 def get_unified(env: Environment, country: str, is_mobile: bool = False) -> Ads:
     """Load Ads from MARS unified api"""
-    user_context_id = uuid.uuid4()
+    context_id = uuid.uuid4()
 
     # placement names will vary for preview and experiment environments, whereas
     # dev & prod have the same placements served by different kevel networks
@@ -328,7 +328,7 @@ def get_unified(env: Environment, country: str, is_mobile: bool = False) -> Ads:
 
     # load spocs & tiles, then map them to the same shape
     body = {
-        "user_context_id": f"{user_context_id}",  # UUID -> str
+        "context_id": f"{context_id}",  # UUID -> str
         "placements": [
             {"placement": spocs_placement, "count": 10},
             {"placement": tile_one_placement, "count": 1},

--- a/consvc_shepherd/tests/test_preview.py
+++ b/consvc_shepherd/tests/test_preview.py
@@ -425,7 +425,7 @@ class TestGetUnified(TestCase):
             mock_unified.assert_called_once_with(
                 f"{mockUnifiedEnv.mars_url}/v1/ads",
                 json={
-                    "user_context_id": mock.ANY,
+                    "context_id": mock.ANY,
                     "placements": [
                         {"placement": "newtab_spocs", "count": 10},
                         {"placement": "newtab_tile_1", "count": 1},
@@ -438,5 +438,5 @@ class TestGetUnified(TestCase):
 
             args, kwargs = mock_unified.call_args
             payload = kwargs["json"]
-            self.assertIsInstance(payload["user_context_id"], str)
-            self.assertEqual(len(payload["user_context_id"]), 36)
+            self.assertIsInstance(payload["context_id"], str)
+            self.assertEqual(len(payload["context_id"]), 36)


### PR DESCRIPTION
## References

Jira: [AE-554](https://mozilla-hub.atlassian.net/browse/AE-554)

## Description
Renames the `user_context_id` variable to `context_id` to make it more clear that this is not aggregating user data.

Related Jira [AE-519](https://mozilla-hub.atlassian.net/browse/AE-519).

## Testing
```
make local-test

app-1  | Required test coverage of 95% reached. Total coverage: 96.73%
app-1  | ================== 65 passed, 1 skipped, 5 warnings in 1.59s ===================
app-1 exited with code 0
```

Unified API Environments (prod/dev) are both working again:
![image](https://github.com/user-attachments/assets/a3514134-66bb-42f7-a4f3-306bacb4b562)

## PR Review Checklist

_Put an `x` in the boxes that apply_

- [x] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
- [x] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
- [x] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
- [x] Functional and performance test coverage has been expanded and maintained (if applicable).

[AE-554]: https://mozilla-hub.atlassian.net/browse/AE-554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AE-519]: https://mozilla-hub.atlassian.net/browse/AE-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ