### PR TITLE
[AE-451] Improve the Shepherd PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -16,4 +16,4 @@ A step by step guide of how the PR reviewer can verify that changes are working 
 
 ## Visuals
 
-If applicable, provide screenshots or videos here with the expected new behavior
+If applicable, provide screenshots or videos here with the expected new behavior. If not, please remove this section.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## References
 
-JIRA: [Jira-task-id](Jira-task-link)
+[Jira-task-id](Jira-task-link)
 
 ## Problem Statement
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,15 @@
 ## References
 
-[Jira-task-id](Jira-task-link)
+[AE-XYZ](https://mozilla-hub.atlassian.net/browse/AE-XYZ)
 
 ## Problem Statement
 
-A brief description of the bugfix or feature that has necessitated this change
+A brief description of the bugfix or feature that has necessitated this change. Provide enough context that a
+reviwer who hasn't been working in this area of the code can understand the intention of this change.
 
 ## Proposed Changes
 
-A description of what has changed in this PR
+A description of what has changed in this PR.
 
 ## Verification Steps
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,19 @@
 ## References
 
-JIRA: [DISCO-TODO](https://mozilla-hub.atlassian.net/browse/DISCO-TODO)
+JIRA: [Jira-task-id](Jira-task-link)
 
-## Description
-<!-- Detail the purpose and impact of this PR, along with any other relevant information including: change highlights, screenshots, test instructions, related documentation, etc .... -->
+## Problem Statement
 
+A brief description of the bugfix or feature that has necessitated this change
 
+## Proposed Changes
 
-## PR Review Checklist
+A description of what has changed in this PR
 
-_Put an `x` in the boxes that apply_
+## Verification Steps
 
-- [ ] This PR conforms to the [Contribution Guidelines](https://github.com/mozilla-services/consvc-shepherd/blob/main/CONTRIBUTING.md).
-- [ ] The PR title starts with the JIRA issue reference, format `[DISCO-####]`, and has the same title (if applicable).
-- [ ] [Documentation](https://github.com/mozilla-services/consvc-shepherd/tree/main/docs) has been updated (if applicable).
-- [ ] Functional and performance test coverage has been expanded and maintained (if applicable).
+A step by step guide of how the PR reviewer can verify that changes are working correctly.
+
+## Visuals
+
+If applicable, provide screenshots or videos here with the expected new behavior


### PR DESCRIPTION
## References

[AE-451](https://mozilla-hub.atlassian.net/browse/AE-541)

## Problem Statement

- We noticed that the PR template references out of date projects like DISCO
- We've recently switched the repo over to squash merging with the PR title as the subject of the commit, and the PR description as the body of the commit, so the existing template no longer makes sense in that context

## Proposed Changes

Update the template to support engineers in providing a good description.

Remove the checklist as that will appear with every PR description in our history and isn't useful metadata about the commit in that context. I'd like to look for another place for such a checklist, perhaps in the contribution guidelines?

## Verification Steps

I'm not sure if there is a way to test-drive this before merging, but I did use the new format for this PR. And I checked the markdown preview and it looks legit from that perspective.


[AE-451]: https://mozilla-hub.atlassian.net/browse/AE-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ