### PR TITLE
Set default request rate to 1 per second for the boostr sync script

### DIFF
--- a/consvc_shepherd/management/commands/sync_boostr_data.py
+++ b/consvc_shepherd/management/commands/sync_boostr_data.py
@@ -13,7 +13,7 @@ from django.core.management.base import BaseCommand
 from consvc_shepherd.models import BoostrDeal, BoostrDealProduct, BoostrProduct
 
 MAX_DEAL_PAGES_DEFAULT = 50
-RATE_LIMIT_REQUEST_INTERVAL_SECS = 0.7
+REQUEST_INTERVAL_SECONDS_DEFAULT = 2
 
 
 class Command(BaseCommand):
@@ -26,7 +26,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "base_url",
             type=str,
-            help="The base url for the Boostr API, eg. https://app.boostr.com/api/",
+            help="The base url for the Boostr API, eg. https://app.boostr.com/api",
         )
         parser.add_argument(
             "--max-deal-pages",
@@ -35,6 +35,14 @@ class Command(BaseCommand):
             help=f"""By default, the sync code will stop trying to fetch additional deals pages after
                 {MAX_DEAL_PAGES_DEFAULT} pages. Currently we have ~14 pages of deals in Boostr, so this default max
                 should be sufficient for a while.""",
+        )
+        parser.add_argument(
+            "--request-interval-seconds",
+            default=REQUEST_INTERVAL_SECONDS_DEFAULT,
+            type=int,
+            help=f"""This parameter controls the rate of requests to the Boostr API in order to stay under their rate
+                limits. By default, the sync code will wait {REQUEST_INTERVAL_SECONDS_DEFAULT} seconds between
+                requests.""",
         )
 
     def handle(self, *args, **options):
@@ -47,7 +55,7 @@ class Command(BaseCommand):
             options["base_url"],
             env("BOOSTR_API_EMAIL"),
             env("BOOSTR_API_PASS"),
-            options["max_deal_pages"],
+            options,
         )
         loader.load()
 
@@ -63,9 +71,11 @@ class BoostrApi:
 
     base_url: str
     session: requests.Session
+    request_interval_seconds: int
 
-    def __init__(self, base_url: str, email: str, password: str):
+    def __init__(self, base_url: str, email: str, password: str, options: dict[str, Any]):
         self.base_url = base_url
+        self.request_interval_seconds = options["request_interval_seconds"]
         self.setup_session(email, password)
 
     def setup_session(self, email: str, password: str) -> None:
@@ -90,7 +100,7 @@ class BoostrApi:
         """Make POST requests to Boostr that uses the session, pass through headers and json data,
         check status, and return parsed json
         """
-        sleep(RATE_LIMIT_REQUEST_INTERVAL_SECS)
+        sleep(self.request_interval_seconds)
         response = self.session.post(
             f"{self.base_url}/{path}",
             json=json,
@@ -108,7 +118,7 @@ class BoostrApi:
         """Make GET requests to Boostr that use the session, pass through headers and query params,
         check status, and return parsed json
         """
-        sleep(RATE_LIMIT_REQUEST_INTERVAL_SECS)
+        sleep(self.request_interval_seconds)
         response = self.session.get(
             f"{self.base_url}/{path}", params=params, headers=headers, timeout=15
         )
@@ -127,10 +137,10 @@ class BoostrLoader:
     log: logging.Logger
     max_deal_pages: int
 
-    def __init__(self, base_url: str, email: str, password: str, max_deal_pages=50):
+    def __init__(self, base_url: str, email: str, password: str, options: dict[str, Any]):
         self.log = logging.getLogger("sync_boostr_data")
-        self.boostr = BoostrApi(base_url, email, password)
-        self.max_deal_pages = max_deal_pages
+        self.boostr = BoostrApi(base_url, email, password, options)
+        self.max_deal_pages = options["max_deal_pages"]
 
     def upsert_products(self) -> None:
         """Fetch all Boostr products and upsert them to Shepherd DB"""

--- a/consvc_shepherd/management/commands/sync_boostr_data.py
+++ b/consvc_shepherd/management/commands/sync_boostr_data.py
@@ -73,7 +73,7 @@ class BoostrApi:
     session: requests.Session
     request_interval_seconds: int
 
-    def __init__(self, base_url: str, email: str, password: str, options: dict[str, Any]):
+    def __init__(self, base_url: str, email: str, password: str, options={}):
         self.base_url = base_url
         self.request_interval_seconds = options["request_interval_seconds"]
         self.setup_session(email, password)
@@ -137,7 +137,7 @@ class BoostrLoader:
     log: logging.Logger
     max_deal_pages: int
 
-    def __init__(self, base_url: str, email: str, password: str, options: dict[str, Any]):
+    def __init__(self, base_url: str, email: str, password: str, options={}):
         self.log = logging.getLogger("sync_boostr_data")
         self.boostr = BoostrApi(base_url, email, password, options)
         self.max_deal_pages = options["max_deal_pages"]

--- a/consvc_shepherd/management/commands/sync_boostr_data.py
+++ b/consvc_shepherd/management/commands/sync_boostr_data.py
@@ -14,6 +14,10 @@ from consvc_shepherd.models import BoostrDeal, BoostrDealProduct, BoostrProduct
 
 MAX_DEAL_PAGES_DEFAULT = 50
 REQUEST_INTERVAL_SECONDS_DEFAULT = 2
+DEFAULT_OPTIONS = {
+    "request_interval_seconds": REQUEST_INTERVAL_SECONDS_DEFAULT,
+    "max_deal_pages": MAX_DEAL_PAGES_DEFAULT,
+}
 
 
 class Command(BaseCommand):
@@ -73,9 +77,13 @@ class BoostrApi:
     session: requests.Session
     request_interval_seconds: int
 
-    def __init__(self, base_url: str, email: str, password: str, options={}):
+    def __init__(
+        self, base_url: str, email: str, password: str, options=DEFAULT_OPTIONS
+    ):
         self.base_url = base_url
-        self.request_interval_seconds = options["request_interval_seconds"]
+        self.request_interval_seconds = options.get(
+            "request_interval_seconds", REQUEST_INTERVAL_SECONDS_DEFAULT
+        )
         self.setup_session(email, password)
 
     def setup_session(self, email: str, password: str) -> None:
@@ -137,10 +145,12 @@ class BoostrLoader:
     log: logging.Logger
     max_deal_pages: int
 
-    def __init__(self, base_url: str, email: str, password: str, options={}):
+    def __init__(
+        self, base_url: str, email: str, password: str, options=DEFAULT_OPTIONS
+    ):
         self.log = logging.getLogger("sync_boostr_data")
         self.boostr = BoostrApi(base_url, email, password, options)
-        self.max_deal_pages = options["max_deal_pages"]
+        self.max_deal_pages = options.get("max_deal_pages", MAX_DEAL_PAGES_DEFAULT)
 
     def upsert_products(self) -> None:
         """Fetch all Boostr products and upsert them to Shepherd DB"""

--- a/consvc_shepherd/management/commands/sync_boostr_data.py
+++ b/consvc_shepherd/management/commands/sync_boostr_data.py
@@ -13,7 +13,7 @@ from django.core.management.base import BaseCommand
 from consvc_shepherd.models import BoostrDeal, BoostrDealProduct, BoostrProduct
 
 MAX_DEAL_PAGES_DEFAULT = 50
-REQUEST_INTERVAL_SECONDS_DEFAULT = 2
+REQUEST_INTERVAL_SECONDS_DEFAULT = 1
 DEFAULT_OPTIONS = {
     "request_interval_seconds": REQUEST_INTERVAL_SECONDS_DEFAULT,
     "max_deal_pages": MAX_DEAL_PAGES_DEFAULT,

--- a/consvc_shepherd/tests/test_sync_boostr.py
+++ b/consvc_shepherd/tests/test_sync_boostr.py
@@ -504,7 +504,7 @@ class TestSyncBoostrData(TestCase):
         mock_sleep,
     ):
         """Test that upsert_deals respects the given max_deal_pages limit"""
-        loader = BoostrLoader(BASE_URL, EMAIL, PASSWORD, 3)
+        loader = BoostrLoader(BASE_URL, EMAIL, PASSWORD, {"max_deal_pages": 3})
         loader.upsert_deals()
         assert 3 == mock_get.call_count
 
@@ -633,12 +633,12 @@ class TestSyncBoostrData(TestCase):
     @mock.patch("requests.Session.post", side_effect=mock_post_success)
     def test_boostr_api_post(self, mock_post_success, mock_sleep):
         """Test the BoostrApi POST wrapper"""
-        boostr = BoostrApi(BASE_URL, EMAIL, PASSWORD)
+        boostr = BoostrApi(BASE_URL, EMAIL, PASSWORD, {"request_interval_seconds": 1})
         auth_json = {"auth": {"email": "email@mozilla.com", "password": "test"}}
         post_json = {"info": "for the server"}
         headers = {"X-Boostr-Whatever": "Stuff"}
         response = boostr.post("some-path", json=post_json, headers=headers)
-        calls = [
+        post_calls = [
             mock.call(
                 f"{BASE_URL}/user_token",
                 json=auth_json,
@@ -654,15 +654,16 @@ class TestSyncBoostrData(TestCase):
         ]
         self.assertEqual(response["data"], "wow")
         self.assertEqual(response["count"], 42)
-        mock_post_success.assert_has_calls(calls)
-        self.assertEqual(mock_sleep.call_count, len(calls))
+        mock_post_success.assert_has_calls(post_calls)
+        sleep_calls = [mock.call(1), mock.call(1)]
+        mock_sleep.assert_has_calls(sleep_calls)
 
     @mock.patch("consvc_shepherd.management.commands.sync_boostr_data.sleep")
     @mock.patch("requests.Session.post", side_effect=mock_post_success)
     @mock.patch("requests.Session.get", side_effect=mock_get_success)
     def test_boostr_api_get(self, mock_get_success, mock_post_success, mock_sleep):
         """Test the BoostrApi GET wrapper"""
-        boostr = BoostrApi(BASE_URL, EMAIL, PASSWORD)
+        boostr = BoostrApi(BASE_URL, EMAIL, PASSWORD, {"request_interval_seconds": 4})
         headers = {"X-Boostr-Whatever": "Stuff"}
         products_params = {
             "per": "300",
@@ -670,7 +671,7 @@ class TestSyncBoostrData(TestCase):
             "filter": "all",
         }
         products = boostr.get("products", headers=headers, params=products_params)
-        calls = [
+        get_calls = [
             mock.call(
                 f"{BASE_URL}/products",
                 params=products_params,
@@ -679,7 +680,11 @@ class TestSyncBoostrData(TestCase):
             ),
         ]
         self.assertEqual(len(products), 2)
-        mock_get_success.assert_has_calls(calls)
-        self.assertEqual(
-            mock_sleep.call_count, 2
-        )  # once for the POST /user_token under the hood, once for GET /products
+        mock_get_success.assert_has_calls(get_calls)
+        sleep_calls = (
+            [  # once for the POST /user_token under the hood, once for GET /products
+                mock.call(4),
+                mock.call(4),
+            ]
+        )
+        mock_sleep.assert_has_calls(sleep_calls)

--- a/consvc_shepherd/tests/test_sync_boostr.py
+++ b/consvc_shepherd/tests/test_sync_boostr.py
@@ -681,10 +681,6 @@ class TestSyncBoostrData(TestCase):
         ]
         self.assertEqual(len(products), 2)
         mock_get_success.assert_has_calls(get_calls)
-        sleep_calls = (
-            [  # once for the POST /user_token under the hood, once for GET /products
-                mock.call(4),
-                mock.call(4),
-            ]
-        )
+        # once for the POST /user_token under the hood, once for GET /products
+        sleep_calls = [mock.call(4), mock.call(4)]
         mock_sleep.assert_has_calls(sleep_calls)

--- a/docs/operations/syncBoostrData.md
+++ b/docs/operations/syncBoostrData.md
@@ -41,7 +41,7 @@ python manage.py sync_boostr_data --max-deal-pages 15
 #### --request-interval-seconds
 The script can take an optional named argument, `--request-interval-seconds`, which
 controls the rate of requests to the Boostr API in order to stay under their rate limits.
-By default, the sync code will wait 2 seconds between requests.
+By default, the sync code will wait 1 second between requests.
 
 Their API's stated rate limits are 100reqs/second, which gives a much higher request rate,
 but in practice we've seen that the actual rate limit is lower, so this can be a helpful way

--- a/docs/operations/syncBoostrData.md
+++ b/docs/operations/syncBoostrData.md
@@ -19,6 +19,7 @@ python manage.py sync_boostr_data https://app.boostr.com/api/
 
 ### Optional arguments
 
+#### --max-deal-pages
 The script can take an optional named argument, `--max-deal-pages`, which will
 set an upper limit on the number of pages of deals that we fetch from the API.
 
@@ -34,8 +35,13 @@ upper limit on deal pages.
 
 Usage:
 ```sh
-python manage.py sync_boostr_data
+python manage.py sync_boostr_data --max-deal-pages 15
 ```
+
+#### --request-interval-seconds
+The script can take an optional named argument, `--max-deal-pages`, which will
+set an upper limit on the number of pages of deals that we fetch from the API.
+
 
 ### Debug logs
 

--- a/docs/operations/syncBoostrData.md
+++ b/docs/operations/syncBoostrData.md
@@ -39,9 +39,18 @@ python manage.py sync_boostr_data --max-deal-pages 15
 ```
 
 #### --request-interval-seconds
-The script can take an optional named argument, `--max-deal-pages`, which will
-set an upper limit on the number of pages of deals that we fetch from the API.
+The script can take an optional named argument, `--request-interval-seconds`, which
+controls the rate of requests to the Boostr API in order to stay under their rate limits.
+By default, the sync code will wait 2 seconds between requests.
 
+Their API's stated rate limits are 100reqs/second, which gives a much higher request rate,
+but in practice we've seen that the actual rate limit is lower, so this can be a helpful way
+to configure a successful full sync of that script.
+
+Usage:
+```sh
+python manage.py sync_boostr_data --request-interval-seconds .5
+```
 
 ### Debug logs
 

--- a/docs/quickStart.md
+++ b/docs/quickStart.md
@@ -68,10 +68,29 @@ python manage.py makemigrations
 python manage.py migrate
 ```
 
-10. Import Boostr Deals and Products
+10. Connect to the DB with `psql`
+
+While the Django Admin interface at /admin shows all the data in our DB in a human readable way, it may sometimes be
+helpful to connect directly to the Shepherd DB while developing. (The values for the DB user and DB name come from
+the `.env` file.)
+
+```sh
+docker exec -it consvc-shepherd-db-1 psql -U postgres postgres
+```
+
+11. Import Boostr Deals and Products
 If you're working with the AdOps dashboard, you may want to pull in Boostr Deals and Products.
+
+First, make sure you have the Boostr API credentials set in your `.env` file. You can find them in 1Password
+
+```
+BOOSTR_API_EMAIL=find-me-in-1password@mozilla.com
+BOOSTR_API_PASS=i-am-in-1password-too
+```
+
+Then, run the script
 
 ``` shell
 docker exec -it consvc-shepherd-app-1 sh # interactive mode
-python manage.py sync_boostr_data https://app.boostr.com/api/ find-me-in-1pass-ads-eng-vault@mozilla.com secret-from-1pass
+python manage.py sync_boostr_data https://app.boostr.com/api
 ```


### PR DESCRIPTION
## Problem Statement

I am not sure that the current request rate setting will allow the script to do a full sync given the Boostr API's rate limits, based on some quick tests I've run. As we're preparing to merge our scheduled job to run this script in all environments on a regular basis, I thought it would be helpful to be able to configure this value. 

## Proposed Changes

* Set up a parameter for the request rate instead of hard coding it, meaning this value can be configurable without making a PR and pushing a code change here.
* Set the default value of requests every 1 seconds for the script. At this default setting, I have managed a successful full sync of the current boostr data in 45 minutes.
* A few additional documentation updates, fixes, and helpful tips

## Verification Steps

The specs verify that the Boostr api wrapper code does in fact wait between requests, and that a specified interval is used by the wrapper. Let me know if you see any other opportunities for adding tests.

For manual verification, you can run the script locally (see `syncBoostrData.md` for usage details) and pass a very high value to see if the script is respecting the value you passed.
