### PR TITLE
Shep 38 makefile improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ dmypy.json
 book/
 mermaid-init.js
 mermaid.min.js
+lcov.info

--- a/Makefile
+++ b/Makefile
@@ -3,117 +3,140 @@ COV_FAIL_UNDER := 95
 INSTALL_STAMP := .install.stamp
 POETRY := $(shell command -v poetry 2> /dev/null)
 VER :=
+MIGRATE ?= true
 
 # This will be run if no target is provided
 .DEFAULT_GOAL := help
 
-.PHONY: help
+.PHONY: help install isort isort-fix black black-fix flake8 bandit pydocstyle mypy lint lint-fix format local-migration-check local-migrate  test doc-install-deps doc doc-preview dev local-test makemigrations-empty migrate makemigrations remove-migration debug
+
 help: ##  show this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[$$()% 0-9a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-.PHONY: install
 install: $(INSTALL_STAMP)  ##  Install dependencies with poetry
 $(INSTALL_STAMP): pyproject.toml poetry.lock
 	@if [ -z $(POETRY) ]; then echo "Poetry could not be found. See https://python-poetry.org/docs/"; exit 2; fi
 	$(POETRY) install
 	touch $(INSTALL_STAMP)
 
-.PHONY: isort
 isort: $(INSTALL_STAMP)  ##  Run isort in --check-only mode
 	@echo "Running isort..."
 	$(POETRY) run isort --check-only $(APP_DIRS) --profile black
 
-.PHONY: isort-fix
 isort-fix: $(INSTALL_STAMP)  ##  Run isort to fix imports
 	@echo "Running isort..."
 	$(POETRY) run isort  $(APP_DIRS) --profile black
 
-.PHONY: black
+
 black: $(INSTALL_STAMP)  ##  Run black
 	@echo "Running black..."
 	$(POETRY) run black --quiet --diff --check --color $(APP_DIRS)
 
-.PHONY: black-fix
 black-fix: $(INSTALL_STAMP)  ##  Format code with Black
 	@echo "Running black with autofix..."
 	$(POETRY) run black --quiet $(APP_DIRS)
 
-.PHONY: flake8
 flake8: $(INSTALL_STAMP)  ##  Run flake8
 	@echo "Running flake8..."
 	$(POETRY) run flake8 $(APP_DIRS) --max-line-length=120
 
-.PHONY: bandit
+
 bandit: $(INSTALL_STAMP)  ##  Run bandit
 	@echo "Running bandit..."
 	$(POETRY) run bandit --quiet -r $(APP_DIRS) -c "pyproject.toml"
 
-.PHONY: pydocstyle
 pydocstyle: $(INSTALL_STAMP)  ##  Run pydocstyle
 	@echo "Running pydocstyle..."	
 	$(POETRY) run pydocstyle $(APP_DIRS) --explain --config="pyproject.toml"
 
-.PHONY: mypy
 mypy: $(INSTALL_STAMP)  ##  Run mypy
 	@echo "Running mypy..."
 	$(POETRY) run mypy $(APP_DIRS) --config-file="pyproject.toml"
 
-.PHONY: lint
-lint: $(INSTALL_STAMP) isort black flake8 bandit pydocstyle mypy ##  Run various lintersk
+lint: $(INSTALL_STAMP) isort black flake8 bandit pydocstyle mypy ##  Run various linters
 
-.PHONY: lint-fix
 lint-fix: $(INSTALL_STAMP) isort-fix black-fix flake8 bandit pydocstyle mypy ##  Run various linters and fix errors to pass CircleCi checks
 
-.PHONY: format
 format: install  ##  Sort imports and reformat code
 	$(POETRY) run isort $(APP_DIRS) --profile black
 	$(POETRY) run black $(APP_DIRS)
 
-.PHONY: local-migration-check
+
 local-migration-check: install
 	$(POETRY) run python manage.py makemigrations --check --dry-run --noinput
 
-.PHONY: local-migrate
 local-migrate: install
 	$(POETRY) run python manage.py makemigrations
 	$(POETRY) run python manage.py migrate
 
-.PHONY: test
 test: local-migration-check
 	env DJANGO_SETTINGS_MODULE=consvc_shepherd.settings $(POETRY) run pytest --cov --cov-report=term-missing --cov-fail-under=$(COV_FAIL_UNDER)
 
-.PHONY: doc-install-deps
 doc-install-deps:  ##  Install the dependencies for doc generation
 	cargo install mdbook && cargo install mdbook-mermaid
 
-.PHONY: doc
 doc: ##  Generate docs via mdBook
 	mdbook-mermaid install && mdbook clean && mdbook build
 
-.PHONY: doc-preview
 doc-preview: doc  ##  Preview Merino docs via the default browser
 	mdbook serve --open
 
-.PHONY: dev
 dev: $(INSTALL_STAMP)  ##  Run shepherd locally and reload automatically
 	docker compose up
 
-.PHONY: local-test
 local-test: $(INSTALL_STAMP)  ##  local test
 	docker compose -f docker-compose.test.yml up --abort-on-container-exit
 
-.PHONY: makemigrations-empty
-makemigrations-empty: ##  Run create an empty migrations file via the docker container
+makemigrations-empty: ##  Create an empty migrations file for manual migrations
 	docker exec -it consvc-shepherd-app-1 python manage.py makemigrations --empty consvc_shepherd
 
-.PHONY: migrate
 migrate: ##  Run migrate on the docker container
 	docker exec -it consvc-shepherd-app-1 python manage.py migrate
 
-.PHONY: makemigrations
-makemigrations: ##  Run makemigrations on the docker container
+
+makemigrations: ##  Run makemigrations on the docker container set MIGRATE=false prevent automatic migration.
+	@echo "Making migrations..."
 	docker exec -it consvc-shepherd-app-1 python manage.py makemigrations
-	
-.PHONY: remove-migration
-remove-migration:  ##  Run command to undo migrations add VER= to set the migration number e.g. 0002
-	docker exec -it consvc-shepherd-app-1 python manage.py migrate consvc_shepherd ${VER}
+	@if [ "$(MIGRATE)" = "true"]; then \
+		echo "Applying migration..."; \
+		docker exec -it consvc-shepherd-app-1 python manage.py migrate; \
+	fi
+
+.PHONY: ruff
+ruff: install
+	$(POETRY) run ruff check --select I --fix
+	$(POETRY) run ruff format
+
+debug: 
+	docker debug consvc-shepherd-app-1
+
+remove-migration: install  ##  Run command to undo migrations add VER= to set the migration number e.g. 0002
+	@if [ -z "$(VER)" ]; then \
+		echo "You must provide a migration version using VER=<version>"; \
+	else \
+		docker exec -it consvc-shepherd-app-1 python manage.py migrate consvc_shepherd ${VER}; \
+	fi
+
+remove-migration-fix: install  ##  Run command to undo migrations, delete the corresponding files, recreate migrations and perform the migration. Add VER= to set the migration number e.g. 0002
+
+	@if [ -z "$(VER)" ]; then \
+		echo "You must provide a migration version using VER=<version>"; \
+	else \
+		echo "Undoing migrations for version $(VER)..."; \
+		docker exec -it consvc-shepherd-app-1 python manage.py migrate consvc_shepherd $(VER); \
+		echo "Removing migration files greater than version $(VER)..."; \
+		for file in consvc_shepherd/migrations/????_*.py; do \
+			base_filename="$${file##*/}"; \
+			migration_number="$${base_filename%%_*}"; \
+			if [ "$${migration_number}" -gt "$(VER)" ]; then \
+				echo "Removing $${file}"; \
+				rm -f "$${file}"; \
+			fi; \
+		done; \
+		echo "Migration files removed."; \
+		echo "Generating New Migration file."; \
+		if [ "$(MIGRATE)" = "true"]; then \
+			docker exec -it consvc-shepherd-app-1 python manage.py makemigrations; \
+			docker exec -it consvc-shepherd-app-1 python manage.py migrate; \
+		fi; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MIGRATE ?= true
 # This will be run if no target is provided
 .DEFAULT_GOAL := help
 
-.PHONY: help install isort isort-fix black black-fix flake8 bandit pydocstyle mypy lint lint-fix format local-migration-check local-migrate  test doc-install-deps doc doc-preview dev local-test makemigrations-empty migrate makemigrations remove-migration debug
+.PHONY: help install isort isort-fix black black-fix flake8 bandit pydocstyle mypy lint lint-fix format local-migration-check local-migrate  test doc-install-deps doc doc-preview dev local-test makemigrations-empty migrate makemigrations remove-migration debug ruff
 
 help: ##  show this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[$$()% 0-9a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -102,12 +102,11 @@ makemigrations: ##  Run makemigrations on the docker container set MIGRATE=false
 		docker exec -it consvc-shepherd-app-1 python manage.py migrate; \
 	fi
 
-.PHONY: ruff
-ruff: install
+ruff: install ##  **Experimental** Run ruff linter. To fix and format files.
 	$(POETRY) run ruff check --select I --fix
 	$(POETRY) run ruff format
 
-debug: 
+debug: ##  Connect to docker container with docker debug.
 	docker debug consvc-shepherd-app-1
 
 remove-migration: install  ##  Run command to undo migrations add VER= to set the migration number e.g. 0002

--- a/poetry.lock
+++ b/poetry.lock
@@ -1688,6 +1688,33 @@ files = [
 pyasn1 = ">=0.1.3"
 
 [[package]]
+name = "ruff"
+version = "0.6.4"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.6.4-py3-none-linux_armv6l.whl", hash = "sha256:c4b153fc152af51855458e79e835fb6b933032921756cec9af7d0ba2aa01a258"},
+    {file = "ruff-0.6.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:bedff9e4f004dad5f7f76a9d39c4ca98af526c9b1695068198b3bda8c085ef60"},
+    {file = "ruff-0.6.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d02a4127a86de23002e694d7ff19f905c51e338c72d8e09b56bfb60e1681724f"},
+    {file = "ruff-0.6.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7862f42fc1a4aca1ea3ffe8a11f67819d183a5693b228f0bb3a531f5e40336fc"},
+    {file = "ruff-0.6.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eebe4ff1967c838a1a9618a5a59a3b0a00406f8d7eefee97c70411fefc353617"},
+    {file = "ruff-0.6.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:932063a03bac394866683e15710c25b8690ccdca1cf192b9a98260332ca93408"},
+    {file = "ruff-0.6.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:50e30b437cebef547bd5c3edf9ce81343e5dd7c737cb36ccb4fe83573f3d392e"},
+    {file = "ruff-0.6.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c44536df7b93a587de690e124b89bd47306fddd59398a0fb12afd6133c7b3818"},
+    {file = "ruff-0.6.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ea086601b22dc5e7693a78f3fcfc460cceabfdf3bdc36dc898792aba48fbad6"},
+    {file = "ruff-0.6.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b52387d3289ccd227b62102c24714ed75fbba0b16ecc69a923a37e3b5e0aaaa"},
+    {file = "ruff-0.6.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0308610470fcc82969082fc83c76c0d362f562e2f0cdab0586516f03a4e06ec6"},
+    {file = "ruff-0.6.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:803b96dea21795a6c9d5bfa9e96127cc9c31a1987802ca68f35e5c95aed3fc0d"},
+    {file = "ruff-0.6.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:66dbfea86b663baab8fcae56c59f190caba9398df1488164e2df53e216248baa"},
+    {file = "ruff-0.6.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:34d5efad480193c046c86608dbba2bccdc1c5fd11950fb271f8086e0c763a5d1"},
+    {file = "ruff-0.6.4-py3-none-win32.whl", hash = "sha256:f0f8968feea5ce3777c0d8365653d5e91c40c31a81d95824ba61d871a11b8523"},
+    {file = "ruff-0.6.4-py3-none-win_amd64.whl", hash = "sha256:549daccee5227282289390b0222d0fbee0275d1db6d514550d65420053021a58"},
+    {file = "ruff-0.6.4-py3-none-win_arm64.whl", hash = "sha256:ac4b75e898ed189b3708c9ab3fc70b79a433219e1e87193b4f2b77251d058d14"},
+    {file = "ruff-0.6.4.tar.gz", hash = "sha256:ac3b5bfbee99973f80aa1b7cbd1c9cbce200883bdd067300c22a6cc1c7fba212"},
+]
+
+[[package]]
 name = "selenium"
 version = "4.21.0"
 description = ""
@@ -1979,4 +2006,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "394d2161cfe9495b8b93b1054d1887404ee04e0a87be8e7e3d6aa01168a3f087"
+content-hash = "e1d25aa959be7152bccb3a1b7847851a1583deafaa6f9ebd71483f28028788cb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ jsonschema = "^4.17.3"
 markus = {extras = ["datadog"], version = "^4.2.0"}
 pyyaml = "^6.0.1"
 requests = "^2.32.0"
+ruff = "^0.6.4"
 
 [tool.poetry.group.dev.dependencies]
 bandit = {extras = ["toml"], version = "^1.7.4"}

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+fix = true
+show-fixes = true
+line-length = 120
+
+
+[lint]
+select = ["S","I","D202","D212"]
+ignore = ["D105","D107","D203", "D205", "D400"]
+fixable = ["ALL"]
+
+[lint.isort]
+order-by-type = true


### PR DESCRIPTION
## References

[SHEP-38](https://mozilla-hub.atlassian.net/browse/SHEP-38)

## Problem Statement

I've noticed a few tasks we  all have to do that are frequent or take multiple steps that are often forgotten when needed. I've added them to our Makefile to streamline development tasks.

I also cleaned up the formatting & arrangement  of the .PHONY commands and improved some of the help descriptions

## Proposed Changes
 modified `make makemigrations` behavior it will now make migrations and automatically migrate. If you just want to create migrations without the migrate run `make makemigrations MIGRATE=false`

added `make ruff` this uses the newer faster ruff linter instead of the multiple tools we currently use. The setting are still being tuned to match the older settings.

added `make debug` uses [docker debug](https://docs.docker.com/reference/cli/docker/debug/) to provide a more full feature cli for our container 

added `make remove-migration-fix VER=WXYZ` this needs a better name. But this simplifies the task of consolidating all the accumulated migration files into one file before merging. With one command you can revert migrations (back to VERY=WXYZ), delete the migration new unneeded files, create a new consolidated migration file and apply it.

## Verification Steps

Test these commands on your local dev env and send feedback on any modifications or update that may be needed.


[SHEP-38]: https://mozilla-hub.atlassian.net/browse/SHEP-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ