### PR TITLE
Test warning improvements

### DIFF
--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -158,8 +158,18 @@ STATIC_URL: str = "static/"
 
 DEFAULT_AUTO_FIELD: str = "django.db.models.BigAutoField"
 
-DEFAULT_FILE_STORAGE: str = "storages.backends.gcloud.GoogleCloudStorage"
-GS_BUCKET_NAME = env("GS_BUCKET_NAME", default="")
+STORAGES: dict[str, Any] = {
+    "default": {
+        "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+        "OPTIONS": {
+            "bucket_name": env("GS_BUCKET_NAME", default=""),
+        },
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
 GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME", default="settings_from_shepherd")
 ALLOCATION_FILE_NAME: str = env("ALLOCATION_FILE_NAME", default="allocation_file")
 

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -193,6 +193,8 @@ LOGGING: dict[str, Any] = {
     },
 }
 
+FORM_RENDERER = "django.forms.renderers.DjangoDivFormRenderer"
+
 # Sentry Setup
 SENTRY_DSN = env("SENTRY_DSN", default=None)
 # Any of "release", "debug", or "disabled". Using "debug" will enable logging for Sentry.

--- a/consvc_shepherd/tests/test_admin.py
+++ b/consvc_shepherd/tests/test_admin.py
@@ -8,6 +8,7 @@ import mock
 from django.contrib.admin.sites import AdminSite
 from django.test import RequestFactory, TestCase, override_settings
 from django.utils import timezone
+import pytz
 from jsonschema import validate
 from markus.testing import MetricsMock
 
@@ -145,7 +146,7 @@ class SettingsSnapshotAdminTest(TestCase):
         """Test that publish snapshot action does not launch pre-existing snapshot."""
         request = mock.Mock()
         request.user = UserFactory()
-        timestamp = datetime(2022, 1, 11, 1, 15, 12)
+        timestamp = datetime(2022, 1, 11, 1, 15, 12, tzinfo=pytz.utc)
         SettingsSnapshot.objects.create(
             name="Settings Snapshot",
             settings_type=self.partner,
@@ -297,7 +298,7 @@ class AllocationSettingsSnapshotAdminTest(TestCase):
         """Test that publish snapshot action does not launch pre-existing snapshot."""
         request = mock.Mock()
         request.user = UserFactory()
-        timestamp = datetime(2023, 5, 19, 1, 15, 12)
+        timestamp = datetime(2023, 5, 19, 1, 15, 12, tzinfo=pytz.utc)
 
         AllocationSettingsSnapshot.objects.create(
             name="Settings Snapshot",

--- a/consvc_shepherd/tests/test_admin.py
+++ b/consvc_shepherd/tests/test_admin.py
@@ -5,10 +5,10 @@ from datetime import datetime
 from typing import Any
 
 import mock
+import pytz
 from django.contrib.admin.sites import AdminSite
 from django.test import RequestFactory, TestCase, override_settings
 from django.utils import timezone
-import pytz
 from jsonschema import validate
 from markus.testing import MetricsMock
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -864,14 +864,17 @@ files = [
 
 [[package]]
 name = "idna"
-version = "3.8"
+version = "3.9"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "idna-3.8-py3-none-any.whl", hash = "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac"},
-    {file = "idna-3.8.tar.gz", hash = "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"},
+    {file = "idna-3.9-py3-none-any.whl", hash = "sha256:69297d5da0cc9281c77efffb4e730254dd45943f45bbfb461de5991713989b1e"},
+    {file = "idna-3.9.tar.gz", hash = "sha256:e5c5dafde284f26e9e0f28f6ea2d6400abd5ca099864a67f576f3981c6476124"},
 ]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -1119,13 +1122,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.3.2"
+version = "4.3.3"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.3.2-py3-none-any.whl", hash = "sha256:eb1c8582560b34ed4ba105009a4badf7f6f85768b30126f351328507b2beb617"},
-    {file = "platformdirs-4.3.2.tar.gz", hash = "sha256:9e5e27a08aa095dd127b9f2e764d74254f482fef22b0970773bfba79d091ab8c"},
+    {file = "platformdirs-4.3.3-py3-none-any.whl", hash = "sha256:50a5450e2e84f44539718293cbb1da0a0885c9d14adf21b77bae4e66fc99d9b5"},
+    {file = "platformdirs-4.3.3.tar.gz", hash = "sha256:d4e0b7d8ec176b341fb03cb11ca12d0276faa8c485f9cd218f613840463fc2c0"},
 ]
 
 [package.extras]
@@ -1456,6 +1459,17 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "pytz"
+version = "2024.2"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
+    {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 description = "YAML parser and emitter for Python"
@@ -1699,29 +1713,29 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "ruff"
-version = "0.6.4"
+version = "0.6.5"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.6.4-py3-none-linux_armv6l.whl", hash = "sha256:c4b153fc152af51855458e79e835fb6b933032921756cec9af7d0ba2aa01a258"},
-    {file = "ruff-0.6.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:bedff9e4f004dad5f7f76a9d39c4ca98af526c9b1695068198b3bda8c085ef60"},
-    {file = "ruff-0.6.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d02a4127a86de23002e694d7ff19f905c51e338c72d8e09b56bfb60e1681724f"},
-    {file = "ruff-0.6.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7862f42fc1a4aca1ea3ffe8a11f67819d183a5693b228f0bb3a531f5e40336fc"},
-    {file = "ruff-0.6.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eebe4ff1967c838a1a9618a5a59a3b0a00406f8d7eefee97c70411fefc353617"},
-    {file = "ruff-0.6.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:932063a03bac394866683e15710c25b8690ccdca1cf192b9a98260332ca93408"},
-    {file = "ruff-0.6.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:50e30b437cebef547bd5c3edf9ce81343e5dd7c737cb36ccb4fe83573f3d392e"},
-    {file = "ruff-0.6.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c44536df7b93a587de690e124b89bd47306fddd59398a0fb12afd6133c7b3818"},
-    {file = "ruff-0.6.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ea086601b22dc5e7693a78f3fcfc460cceabfdf3bdc36dc898792aba48fbad6"},
-    {file = "ruff-0.6.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b52387d3289ccd227b62102c24714ed75fbba0b16ecc69a923a37e3b5e0aaaa"},
-    {file = "ruff-0.6.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0308610470fcc82969082fc83c76c0d362f562e2f0cdab0586516f03a4e06ec6"},
-    {file = "ruff-0.6.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:803b96dea21795a6c9d5bfa9e96127cc9c31a1987802ca68f35e5c95aed3fc0d"},
-    {file = "ruff-0.6.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:66dbfea86b663baab8fcae56c59f190caba9398df1488164e2df53e216248baa"},
-    {file = "ruff-0.6.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:34d5efad480193c046c86608dbba2bccdc1c5fd11950fb271f8086e0c763a5d1"},
-    {file = "ruff-0.6.4-py3-none-win32.whl", hash = "sha256:f0f8968feea5ce3777c0d8365653d5e91c40c31a81d95824ba61d871a11b8523"},
-    {file = "ruff-0.6.4-py3-none-win_amd64.whl", hash = "sha256:549daccee5227282289390b0222d0fbee0275d1db6d514550d65420053021a58"},
-    {file = "ruff-0.6.4-py3-none-win_arm64.whl", hash = "sha256:ac4b75e898ed189b3708c9ab3fc70b79a433219e1e87193b4f2b77251d058d14"},
-    {file = "ruff-0.6.4.tar.gz", hash = "sha256:ac3b5bfbee99973f80aa1b7cbd1c9cbce200883bdd067300c22a6cc1c7fba212"},
+    {file = "ruff-0.6.5-py3-none-linux_armv6l.whl", hash = "sha256:7e4e308f16e07c95fc7753fc1aaac690a323b2bb9f4ec5e844a97bb7fbebd748"},
+    {file = "ruff-0.6.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:932cd69eefe4daf8c7d92bd6689f7e8182571cb934ea720af218929da7bd7d69"},
+    {file = "ruff-0.6.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a8d42d11fff8d3143ff4da41742a98f8f233bf8890e9fe23077826818f8d680"},
+    {file = "ruff-0.6.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a50af6e828ee692fb10ff2dfe53f05caecf077f4210fae9677e06a808275754f"},
+    {file = "ruff-0.6.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:794ada3400a0d0b89e3015f1a7e01f4c97320ac665b7bc3ade24b50b54cb2972"},
+    {file = "ruff-0.6.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:381413ec47f71ce1d1c614f7779d88886f406f1fd53d289c77e4e533dc6ea200"},
+    {file = "ruff-0.6.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:52e75a82bbc9b42e63c08d22ad0ac525117e72aee9729a069d7c4f235fc4d276"},
+    {file = "ruff-0.6.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09c72a833fd3551135ceddcba5ebdb68ff89225d30758027280968c9acdc7810"},
+    {file = "ruff-0.6.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:800c50371bdcb99b3c1551d5691e14d16d6f07063a518770254227f7f6e8c178"},
+    {file = "ruff-0.6.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e25ddd9cd63ba1f3bd51c1f09903904a6adf8429df34f17d728a8fa11174253"},
+    {file = "ruff-0.6.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7291e64d7129f24d1b0c947ec3ec4c0076e958d1475c61202497c6aced35dd19"},
+    {file = "ruff-0.6.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:9ad7dfbd138d09d9a7e6931e6a7e797651ce29becd688be8a0d4d5f8177b4b0c"},
+    {file = "ruff-0.6.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:005256d977021790cc52aa23d78f06bb5090dc0bfbd42de46d49c201533982ae"},
+    {file = "ruff-0.6.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:482c1e6bfeb615eafc5899127b805d28e387bd87db38b2c0c41d271f5e58d8cc"},
+    {file = "ruff-0.6.5-py3-none-win32.whl", hash = "sha256:cf4d3fa53644137f6a4a27a2b397381d16454a1566ae5335855c187fbf67e4f5"},
+    {file = "ruff-0.6.5-py3-none-win_amd64.whl", hash = "sha256:3e42a57b58e3612051a636bc1ac4e6b838679530235520e8f095f7c44f706ff9"},
+    {file = "ruff-0.6.5-py3-none-win_arm64.whl", hash = "sha256:51935067740773afdf97493ba9b8231279e9beef0f2a8079188c4776c25688e0"},
+    {file = "ruff-0.6.5.tar.gz", hash = "sha256:4d32d87fab433c0cf285c3683dd4dae63be05fd7a1d65b3f5bf7cdd05a6b96fb"},
 ]
 
 [[package]]
@@ -1925,13 +1939,13 @@ files = [
 
 [[package]]
 name = "types-pytz"
-version = "2024.1.0.20240417"
+version = "2024.2.0.20240913"
 description = "Typing stubs for pytz"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-pytz-2024.1.0.20240417.tar.gz", hash = "sha256:6810c8a1f68f21fdf0f4f374a432487c77645a0ac0b31de4bf4690cf21ad3981"},
-    {file = "types_pytz-2024.1.0.20240417-py3-none-any.whl", hash = "sha256:8335d443310e2db7b74e007414e74c4f53b67452c0cb0d228ca359ccfba59659"},
+    {file = "types-pytz-2024.2.0.20240913.tar.gz", hash = "sha256:4433b5df4a6fc587bbed41716d86a5ba5d832b4378e506f40d34bc9c81df2c24"},
+    {file = "types_pytz-2024.2.0.20240913-py3-none-any.whl", hash = "sha256:a1eebf57ebc6e127a99d2fa2ba0a88d2b173784ef9b3defcc2004ab6855a44df"},
 ]
 
 [[package]]
@@ -1947,13 +1961,13 @@ files = [
 
 [[package]]
 name = "types-requests"
-version = "2.32.0.20240907"
+version = "2.32.0.20240914"
 description = "Typing stubs for requests"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-requests-2.32.0.20240907.tar.gz", hash = "sha256:ff33935f061b5e81ec87997e91050f7b4af4f82027a7a7a9d9aaea04a963fdf8"},
-    {file = "types_requests-2.32.0.20240907-py3-none-any.whl", hash = "sha256:1d1e79faeaf9d42def77f3c304893dea17a97cae98168ac69f3cb465516ee8da"},
+    {file = "types-requests-2.32.0.20240914.tar.gz", hash = "sha256:2850e178db3919d9bf809e434eef65ba49d0e7e33ac92d588f4a5e295fffd405"},
+    {file = "types_requests-2.32.0.20240914-py3-none-any.whl", hash = "sha256:59c2f673eb55f32a99b2894faf6020e1a9f4a402ad0f192bfee0b64469054310"},
 ]
 
 [package.dependencies]
@@ -1983,13 +1997,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.2"
+version = "2.2.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"},
-    {file = "urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"},
+    {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
+    {file = "urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"},
 ]
 
 [package.dependencies]
@@ -2034,4 +2048,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "bc0ae1e8221a4906e58f2df5bbd4084d36406e5bb20b857681af3a2511a5dc70"
+content-hash = "7028311df5956fb6f81502194d13a0eb097849b61e4028095d954f89f1076760"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ markus = { extras = ["datadog"], version = "^4.2.0" }
 pyyaml = "^6.0.1"
 requests = "^2.32.0"
 ruff = "^0.6.4"
+pytz = "^2024.2"
 djangorestframework = "^3.15.2"
 django-cors-headers = "^4.4.0"
 


### PR DESCRIPTION
## References

[SHEP-43](https://mozilla-hub.atlassian.net/browse/SHEP-43)

## Problem Statement

When we ran our tests, a few warnings appeared. While they don't cause the tests to fail and are easy to ignore, I decided to investigate and fix them. By addressing these warnings, we can make our code more reliable and reduce potential issues when updating to the next version of Django.

## Proposed Changes

This PR fixes warnings we encountered when we ran our tests. Here is an overview of changes:

1. `RemovedInDjango51Warning: The DEFAULT_FILE_STORAGE setting is deprecated`: 
 - Django 4.2 changed how storage objects are configured so its easier to configure multiple storage objects. As a result, DEFAULT_FILE_STORAGE has been deprecated in favor of STORAGES. DEFAULT_FILE_STORAGE will be removed on Django 5.1.
 - For more info check [Google Cloud Storage Configuration](https://django-storages.readthedocs.io/en/latest/backends/gcloud.html#configuration-settings).
 
2. `RuntimeWarning: DateTimeField SettingsSnapshot.launched_date received a naive datetime`:
 - We were creating naive datetime objects (timestamp) but filtering for aware datetime objects (launched_date). The main difference between these two types of objects is that naive datetime objects don't store any timezone information, which triggers the warning.
  - To fix this, we attach a test timezone (UTC) to the timestamp objects, so both now follow the same format.
  - For more info, see [Django Timezone Support](https://docs.djangoproject.com/en/5.1/topics/i18n/timezones/).

3. `RemovedInDjango50Warning: The "default.html" templates for forms and formsets will be removed`:
 - This warning occurred because Django 4.2 introduced new <div>-based form templates that improve form rendering accessibility, which will eventually replace the previous form and formset templates.
 - This commit adds the FORM_RENDERER setting that configures Django to use the new form style.
 - Once the new <div> output style becomes the default in Django 5.0, this setting can be removed and will be fully deprecated in Django 6.0.
 - Form more info, check [Django 4.2 release notes](https://docs.djangoproject.com/en/4.2/releases/4.1/#form-rendering-accessibility).

*Note*: There is still a warning that will show up that we don't control: `DeprecationWarning: pkg_resources is deprecated as an API`
- We can't fix it because we don’t use `pkg_resources` directly. This warning occurs because `setuptools`, one of our dependencies, uses a deprecated `pkg_resources` API, and the warning cascades to us. This should resolve itself in the future when setup `setuptools` releases a version with a fix.

## Verification Steps

Run `make local-test` to make sure tests are passing. You should see that there is only 1 warning on this branch (instead of 5 on main)

Before:
```
app-1  | =============================== warnings summary ===============================
app-1  | ../root/.cache/pypoetry/virtualenvs/consvc-shepherd-9TtSrW0h-py3.11/lib/python3.11/site-packages/django/conf/__init__.py:278
app-1  |   /root/.cache/pypoetry/virtualenvs/consvc-shepherd-9TtSrW0h-py3.11/lib/python3.11/site-packages/django/conf/__init__.py:278: RemovedInDjango51Warning: The DEFAULT_FILE_STORAGE setting is deprecated. Use STORAGES instead.
app-1  |     warnings.warn(DEFAULT_FILE_STORAGE_DEPRECATED_MSG, RemovedInDjango51Warning)
app-1  | 
app-1  | ../root/.cache/pypoetry/virtualenvs/consvc-shepherd-9TtSrW0h-py3.11/lib/python3.11/site-packages/polymorphic/__init__.py:9
app-1  |   /root/.cache/pypoetry/virtualenvs/consvc-shepherd-9TtSrW0h-py3.11/lib/python3.11/site-packages/polymorphic/__init__.py:9: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
app-1  |     import pkg_resources
app-1  | 
app-1  | consvc_shepherd/tests/test_admin.py::SettingsSnapshotAdminTest::test_publish_snapshot_does_not_launch_already_launch_snapshot
app-1  |   /root/.cache/pypoetry/virtualenvs/consvc-shepherd-9TtSrW0h-py3.11/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField SettingsSnapshot.launched_date received a naive datetime (2022-01-11 01:15:12) while time zone support is active.
app-1  |     warnings.warn(
app-1  | 
app-1  | consvc_shepherd/tests/test_admin.py::AllocationSettingsSnapshotAdminTest::test_publish_snapshot_does_not_launch_already_launch_snapshot
app-1  |   /root/.cache/pypoetry/virtualenvs/consvc-shepherd-9TtSrW0h-py3.11/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField AllocationSettingsSnapshot.launched_date received a naive datetime (2023-05-19 01:15:12) while time zone support is active.
app-1  |     warnings.warn(
app-1  | 
app-1  | consvc_shepherd/tests/test_views.py::TestTableOverviewCompareSnapshot::test_view_returns_post_request
app-1  |   /root/.cache/pypoetry/virtualenvs/consvc-shepherd-9TtSrW0h-py3.11/lib/python3.11/site-packages/django/template/base.py:1047: RemovedInDjango50Warning: The "default.html" templates for forms and formsets will be removed. These were proxies to the equivalent "table.html" templates, but the new "div.html" templates will be the default fromte Django 5.0. Transitional renderers are provided to allow you to opt-in to the new output style now. See https://docs.djangoproject.com/en/4.2/releases/4.1/ for more details
```

After:
```
 =============================== warnings summary ===============================
app-1  | ../root/.cache/pypoetry/virtualenvs/consvc-shepherd-9TtSrW0h-py3.11/lib/python3.11/site-packages/polymorphic/__init__.py:9
app-1  |   /root/.cache/pypoetry/virtualenvs/consvc-shepherd-9TtSrW0h-py3.11/lib/python3.11/site-packages/polymorphic/__init__.py:9: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
app-1  |     import pkg_resources
```



[SHEP-43]: https://mozilla-hub.atlassian.net/browse/SHEP-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ