### PR TITLE
SHEP66/65: Add new countries to preview

### DIFF
--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -30,9 +30,9 @@ LOCALIZATIONS = {
         "LU": "Sponsorisé",
         "CH": "Gesponsert",
         "BE": "Gesponsord",
-        "JP": "Sponsored",
+        "JP": "広告",
         "SG": "Sponsored",
-        "SE": "Sponsored",
+        "SE": "Sponsrad",
     },
     "Sponsored by": {
         "US": "Sponsored by {sponsor}",
@@ -48,9 +48,9 @@ LOCALIZATIONS = {
         "LU": "Sponsorisé par {sponsor}",
         "CH": "Werbung von {sponsor}",
         "BE": "Gesponsord door {sponsor}",
-        "JP": "Sponsored by {sponsor}",
+        "JP": "提供 {sponsor}",
         "SG": "Sponsored by {sponsor}",
-        "SE": "Sponsored by {sponsor}",
+        "SE": "Sponsrad av {sponsor}",
     },
 }
 

--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -30,6 +30,9 @@ LOCALIZATIONS = {
         "LU": "Sponsorisé",
         "CH": "Gesponsert",
         "BE": "Gesponsord",
+        "JP": "Sponsored",
+        "SG": "Sponsored",
+        "SE": "Sponsored",
     },
     "Sponsored by": {
         "US": "Sponsored by {sponsor}",
@@ -45,6 +48,9 @@ LOCALIZATIONS = {
         "LU": "Sponsorisé par {sponsor}",
         "CH": "Werbung von {sponsor}",
         "BE": "Gesponsord door {sponsor}",
+        "JP": "Sponsored by {sponsor}",
+        "SG": "Sponsored by {sponsor}",
+        "SE": "Sponsored by {sponsor}",
     },
 }
 
@@ -193,6 +199,10 @@ COUNTRIES: list[Region] = [
     Region(code="DE", name="Germany"),
     Region(code="ES", name="Spain"),
     Region(code="FR", name="France"),
+    Region(code="SG", name="Singapore"),
+    Region(code="SE", name="Sweden"),
+    Region(code="JP", name="Japan"),
+    Region(code="NL", name="Netherlands"),
     Region(code="GB", name="United Kingdom"),
     Region(code="IT", name="Italy"),
     Region(code="PL", name="Poland"),

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -59,12 +59,15 @@ COUNTRIES_ONLY: list[str] = [
     "FR",
     "GB",
     "IN",
+    "JP",
     "IT",
     "JP",
     "LU",
     "MX",
     "NL",
     "PL",
+    "SE",
+    "SG",
     "US",
 ]
 COUNTRIES_FIRST_SORT: bool = True


### PR DESCRIPTION
## References

[SHEP-66](https://mozilla-hub.atlassian.net/browse/SHEP-66)
[SHEP-65](https://mozilla-hub.atlassian.net/browse/SHEP-65)

## Problem Statement

We will be launching tiles in new regions, so we need to show these new countries in the shepherd preview UI.

## Proposed Changes

- Add Singapore (SG), Sweden (SE), Netherlands (NL) and Japan (JP) to the list of countries in shepherd supports.

## Verification Steps

Run locally and see that these countries show up in the dropdown.


[SHEP-66]: https://mozilla-hub.atlassian.net/browse/SHEP-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHEP-65]: https://mozilla-hub.atlassian.net/browse/SHEP-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ