### PR TITLE
Shep 76 makefile improvements enhance ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,11 @@ makemigrations: ##  Run makemigrations on the docker container set MIGRATE=false
 	fi
 
 ruff: install ##  **Experimental** Run ruff linter. To fix and format files.
+	@echo "Running Ruff..."
 	$(POETRY) run ruff check --select I --fix
 	$(POETRY) run ruff format
+	@echo "Running Mypy..."
+	$(POETRY) run mypy $(APP_DIRS) --config-file="pyproject.toml"
 
 debug: ##  Connect to the shepherd container with docker debug.
 	docker debug consvc-shepherd-app-1

--- a/Makefile
+++ b/Makefile
@@ -103,11 +103,12 @@ makemigrations: ##  Run makemigrations on the docker container set MIGRATE=false
 	fi
 
 ruff: install ##  **Experimental** Run ruff linter. To fix and format files.
+	@echo "Running Mypy..."
+	$(POETRY) run mypy $(APP_DIRS) --config-file="pyproject.toml"
 	@echo "Running Ruff..."
 	$(POETRY) run ruff check
 	$(POETRY) run ruff format
-	@echo "Running Mypy..."
-	$(POETRY) run mypy $(APP_DIRS) --config-file="pyproject.toml"
+	
 
 
 debug: ##  Connect to the shepherd container with docker debug.

--- a/Makefile
+++ b/Makefile
@@ -104,10 +104,11 @@ makemigrations: ##  Run makemigrations on the docker container set MIGRATE=false
 
 ruff: install ##  **Experimental** Run ruff linter. To fix and format files.
 	@echo "Running Ruff..."
-	$(POETRY) run ruff check --select I --fix
+	$(POETRY) run ruff check
 	$(POETRY) run ruff format
 	@echo "Running Mypy..."
 	$(POETRY) run mypy $(APP_DIRS) --config-file="pyproject.toml"
+
 
 debug: ##  Connect to the shepherd container with docker debug.
 	docker debug consvc-shepherd-app-1

--- a/ruff.toml
+++ b/ruff.toml
@@ -33,6 +33,7 @@ exclude = [
     "venv",
     "migrations",
     "manage.py",
+    "*test_*.py",
 ]
 
 [lint]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,12 +1,68 @@
 fix = true
 show-fixes = true
 line-length = 120
+indent-width = 4
+respect-gitignore = true
 
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+    "migrations",
+    "manage.py",
+]
 
 [lint]
-select = ["S","I","D202","D212"]
-ignore = ["D105","D107","D203", "D205", "D400"]
+select = ["E","W","S","I","B","D202","D212"]
+ignore = ["D105","D107","D203", "D205", "D400","S101", "S104"]
 fixable = ["ALL"]
 
 [lint.isort]
 order-by-type = true
+
+[lint.pydocstyle]
+convention = "pep257"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+docstring-code-line-length = "dynamic"


### PR DESCRIPTION
## References

[SHEP-76](https://mozilla-hub.atlassian.net/browse/SHEP-76)

## Problem Statement

We currently use 6 different linting tools which can tend to be slow to run multiple times during the dev cycle.

## Proposed Changes

Experiment with consolidating most of the linters to [ruff](https://astral.sh/ruff) a modern fast linter and code formatter written in rust.  We'll benefit from a faster linting process and consolidation to just 2 tools (ruff and mypy)

## Verification Steps

Test `make lint-fix` and compare with `make ruff`
make ruff should fix everything make lint-fix can do, with a noticeable difference that it will format all line lengths to max 120 chars. See #216 for past discussion on this change

[SHEP-76]: https://mozilla-hub.atlassian.net/browse/SHEP-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ