### PR TITLE
Gracefully handle 204 responses from /v1/tiles on Preview page

### DIFF
--- a/consvc_shepherd/preview.py
+++ b/consvc_shepherd/preview.py
@@ -314,6 +314,10 @@ def get_amp_tiles(
     r = requests.get(
         f"{env.mars_url}/v1/tiles", params=params, headers=headers, timeout=30
     )
+
+    if r.status_code == 204:
+        return []
+
     return [
         Tile(
             image_url=tile["image_url"],

--- a/consvc_shepherd/tests/test_preview.py
+++ b/consvc_shepherd/tests/test_preview.py
@@ -99,7 +99,9 @@ class TestGetAmpTiles(TestCase):
             "requests.get",
             side_effect=self.mock_amp_tiles_data,
         ) as mock_amp_tiles:
-            tiles = get_amp_tiles(self.MOCK_ENV, "US", "CA", DEFAULT_USER_AGENT.user_agent)
+            tiles = get_amp_tiles(
+                self.MOCK_ENV, "US", "CA", DEFAULT_USER_AGENT.user_agent
+            )
 
             mock_amp_tiles.assert_called()
 
@@ -127,7 +129,9 @@ class TestGetAmpTiles(TestCase):
             "requests.get",
             return_value=mock.Mock(status_code=204),
         ) as mock_amp_tiles:
-            tiles = get_amp_tiles(self.MOCK_ENV, "US", "CA", DEFAULT_USER_AGENT.user_agent)
+            tiles = get_amp_tiles(
+                self.MOCK_ENV, "US", "CA", DEFAULT_USER_AGENT.user_agent
+            )
 
             mock_amp_tiles.assert_called()
 

--- a/consvc_shepherd/tests/test_preview.py
+++ b/consvc_shepherd/tests/test_preview.py
@@ -61,6 +61,16 @@ DEFAULT_USER_AGENT = FormFactor(
 class TestGetAmpTiles(TestCase):
     """Test the Fetching of Tiles for the Preview Page."""
 
+    MOCK_ENV = Environment(
+        code="mock",
+        name="Mock",
+        mars_url="https://mars.mock.if.you.are.connecting.to.this.the.test.broke.com",
+        spoc_site_id=1234567,
+        spoc_site_id_mobile=1234567,
+        spoc_zone_ids=[],
+        direct_sold_tile_zone_ids=[424242],
+    )
+
     def mock_amp_tiles_data(self, *args, **kwargs):
         """Mock out the function that wraps 'GET /v1/tiles' request within get_amp_tiles"""
         response = {
@@ -89,23 +99,7 @@ class TestGetAmpTiles(TestCase):
             "requests.get",
             side_effect=self.mock_amp_tiles_data,
         ) as mock_amp_tiles:
-            mockEnv = Environment(
-                code="mock",
-                name="Mock",
-                mars_url="https://mars.mock.if.you.are.connecting.to.this.the.test.broke.com",
-                spoc_site_id=1234567,
-                spoc_site_id_mobile=1234567,
-                spoc_zone_ids=[],
-                direct_sold_tile_zone_ids=[424242],
-            )
-            mockFormFactor = FormFactor(
-                code="desktop",
-                name="Desktop",
-                is_mobile=False,
-                user_agent="Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0",
-            )
-
-            tiles = get_amp_tiles(mockEnv, "US", "CA", mockFormFactor.user_agent)
+            tiles = get_amp_tiles(self.MOCK_ENV, "US", "CA", DEFAULT_USER_AGENT.user_agent)
 
             mock_amp_tiles.assert_called()
 
@@ -121,11 +115,23 @@ class TestGetAmpTiles(TestCase):
 
             # Verify that requests.get was called once with the expected parameters
             mock_amp_tiles.assert_called_once_with(
-                f"{mockEnv.mars_url}/v1/tiles",
+                f"{self.MOCK_ENV.mars_url}/v1/tiles",
                 params={"country": "US", "region": "CA"},
-                headers={"User-Agent": mockFormFactor.user_agent},
+                headers={"User-Agent": DEFAULT_USER_AGENT.user_agent},
                 timeout=30,
             )
+
+    def test_get_amp_tiles_204(self):
+        """Test a 204 response from /v1/tiles."""
+        with mock.patch(
+            "requests.get",
+            return_value=mock.Mock(status_code=204),
+        ) as mock_amp_tiles:
+            tiles = get_amp_tiles(self.MOCK_ENV, "US", "CA", DEFAULT_USER_AGENT.user_agent)
+
+            mock_amp_tiles.assert_called()
+
+            self.assertEqual(len(tiles), 0)
 
 
 @override_settings(DEBUG=True)


### PR DESCRIPTION
## Problem Statement

The /v1/tiles endpoint returns a 204 response with no body when there are no tiles available. Currently when this happens, get_amp_tiles raises an exception, and we don't display any ads (even if e.g. SPOCs might be available):

![Screenshot 2024-10-03 at 2 50 12 PM](https://github.com/user-attachments/assets/f05c6690-c032-4dbf-896e-d47745e21048)

## Proposed Changes

This changes get_amp_tiles to gracefully handle a 204 response from /v1/tiles and allows the preview page to display other ads that migth be available.

## Verification Steps

This can be tricky to verify, as tiles _should_ almost always available for the countries/regions currently supported by the preview page. However, at time of writing, they are not available for Canada, as seen in the above screenshot.

To verify:
1. Go to the Preview page
2. Pick a country/region where tiles are not available, and hit Preview
3. Observe that SPOCs are shown

## Visuals

![Screenshot 2024-10-03 at 2 50 27 PM](https://github.com/user-attachments/assets/a087a32e-85dd-4c2a-aada-513a87cbca80)
