### PR TITLE
[SHEP-70]: Add flight_name to BQ query in sync_bq_script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ book/
 mermaid-init.js
 mermaid.min.js
 lcov.info
+
+# ADC
+application_default_credentials.json

--- a/consvc_shepherd/management/commands/sync_bq_data.py
+++ b/consvc_shepherd/management/commands/sync_bq_data.py
@@ -77,6 +77,7 @@ class BQSyncer:
                 campaign_id,
                 campaign_name,
                 flight_id,
+                flight_name,
                 provider,
                 SUM(clicks) AS clicks,
                 SUM(impressions) AS impressions
@@ -91,6 +92,7 @@ class BQSyncer:
                 campaign_id,
                 campaign_name,
                 flight_id,
+                flight_name,
                 provider
         """
 
@@ -125,6 +127,7 @@ class BQSyncer:
             campaign_id = row["campaign_id"]
             campaign_name = row["campaign_name"]
             flight_id = row["flight_id"]
+            flight_name = row["flight_name"]
             provider = row["provider"]
             clicks = row["clicks"]
             impressions = row["impressions"]
@@ -134,6 +137,7 @@ class BQSyncer:
                 campaign_id=campaign_id,
                 campaign_name=campaign_name,
                 flight_id=flight_id,
+                flight_name=flight_name,
                 provider=provider,
                 # If script runs again in the same day, just update the clicks and impressions
                 defaults={

--- a/consvc_shepherd/tests/test_sync_bq_data.py
+++ b/consvc_shepherd/tests/test_sync_bq_data.py
@@ -29,6 +29,7 @@ class TestBQSyncerData(TestCase):
                 "campaign_id": [1],
                 "campaign_name": ["Campaign 1"],
                 "flight_id": [100],
+                "flight_name": ["Flight 1"],
                 "provider": ["Provider 1"],
                 "clicks": [10],
                 "impressions": [100],
@@ -50,6 +51,7 @@ class TestBQSyncerData(TestCase):
             campaign_id=1,
             campaign_name="Campaign 1",
             flight_id=100,
+            flight_name="Flight 1",
             provider="Provider 1",
             defaults={
                 "clicks_delivered": 10,
@@ -122,6 +124,7 @@ class TestBQSyncerData(TestCase):
                 "campaign_id": [1, 2],
                 "campaign_name": ["Campaign 1", "Campaign 2"],
                 "flight_id": [100, 101],
+                "flight_name": ["Flight 1", "Flight 2"],
                 "provider": ["Provider 1", "Provider 2"],
                 "clicks": [10, 20],
                 "impressions": [100, 200],
@@ -152,12 +155,11 @@ class TestBQSyncerData(TestCase):
         mock_query_job.result.return_value.total_rows = 1
         mock_query_job.result.return_value.to_dataframe.return_value = pd.DataFrame(
             {
-                "submission_date": [
-                    datetime.today().strftime("%Y-%m-%d")
-                ],  # Today's date
+                "submission_date": [datetime.today().strftime("%Y-%m-%d")],
                 "campaign_id": [1],
                 "campaign_name": ["Campaign 1"],
                 "flight_id": [100],
+                "flight_name": ["Flight 1"],
                 "provider": ["Provider 1"],
                 "clicks": [10],
                 "impressions": [100],
@@ -177,6 +179,7 @@ class TestBQSyncerData(TestCase):
             campaign_id=1,
             campaign_name="Campaign 1",
             flight_id=100,
+            flight_name="Flight 1",
             provider="Provider 1",
             defaults={
                 "clicks_delivered": 10,


### PR DESCRIPTION
## References

[SHEP-70](https://mozilla-hub.atlassian.net/browse/SHEP-70)

## Problem Statement

We received feedback from the Ad Ops folks that it would be good to see the flight name in the Delivered Flights table as well. This PR includes the flight_name to the BQ query in the sync_bq_script.

## Proposed Changes

- Update `sync_bq_data` script to also query for the flight name
- Update `test_sync_bq_data` tests to also include and test the flight name

## Verification Steps

1. Start Shepherd with `docker compose up --build`
1. Pass your gcloud credentials to the shepherd container to access the BigQuery view `moz-fx-data-shared-prod.ads.consolidated_ad_metrics_daily_pt`:
    1. Login to gcloud locally `gcloud auth application-default login`.
    2. Copy your gcloud creds into the shepherd container:
   ```bash
   docker cp ~/.config/gcloud/application_default_credentials.json consvc-shepherd-app-1:/app/application_default_credentials.json
   ```
1. Exec into the Shepherd container with `make debug`.
1. Tell gcloud to use the creds with:
    ```bash
    export GOOGLE_APPLICATION_CREDENTIALS="/app/application_default_credentials.json"
    ```
1. Run the script
    ```bash
    python manage.py sync_bq_data --project_id "moz-fx-ads-nonprod"
    ```
    If successful you should see: `BigQuery fetch completed for data <today's date>`.
1. Now that the `consvc_shepherd_deliveredflight` table was populated with flight info, check that the flights also show the flight name in the Delivered Flights UI: http://0.0.0.0:7001/admin/consvc_shepherd/deliveredflight/

[SHEP-70]: https://mozilla-hub.atlassian.net/browse/SHEP-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ