### PR TITLE
Revert "GHA maintenance (#274)"

### DIFF
--- a/.github/workflows/build_and_push_to_gar.yml
+++ b/.github/workflows/build_and_push_to_gar.yml
@@ -8,74 +8,7 @@ on:
     tags:
       - v.[0-9]+rc[0-9]+
 
-env:
-  NODE_VERSION: 20
-  PYTHON_VERSION: 3.11
-  POETRY_VERSION: 1.8.3
-
 jobs:
-  lint:
-    name: lint
-    runs-on:
-      - ubuntu-latest
-
-    environment: build
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-
-      - name: install poetry
-        run: |-
-          python -m pip install poetry==${{ env.POETRY_VERSION }}
-
-      - name: setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
-
-      - name: setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: ad-ops-dashboard/package-lock.json
-
-      - name: make lint
-        run: |-
-          make -k lint
-
-  test:
-    name: test
-    runs-on:
-      - ubuntu-latest
-
-    environment: build
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-
-      - name: install poetry
-        run: |-
-          python -m pip install poetry==${{ env.POETRY_VERSION }}
-
-      - name: setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
-
-      - name: setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: ad-ops-dashboard/package-lock.json
-
-      - name: make test
-        run: |-
-          make test
-
   build-and-push:
     name: build and push
     runs-on:
@@ -94,15 +27,6 @@ jobs:
       - id: set-tag
         run: |-
           echo TAG=$(cd src; git describe --tags --abbrev=4 2>/dev/null || git rev-parse --short=8 HEAD) | tee -a ${GITHUB_OUTPUT}
-
-      - id: generate_version_json
-        name: generate version.json
-        run: |-
-          printf '{"commit":"%s","version":"%s","source":"%s","build":"%s"}\n' \
-            "$(cd src; git rev-parse HEAD)" \
-            "${{ steps.set-tag.outputs.TAG }}" \
-            "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
-            "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" |tee src/version.json
 
       - uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
This reverts commit 22bb3f76f8cef6d5c63c577935309a53e6cdd217.

## Problem Statement

I merged André's PR for updates to the github actions. I think I viewed it in an earlier stage when it was just adding node linting and testing to the PR. It looks like the final change added `lint` and `test` workflows, but it looks like there is additional environment setup needed for the test workflows to succeed. Here's an example of the failed run:

https://github.com/mozilla-services/consvc-shepherd/actions/runs/11296454474/job/31421725378

Also, I think that if the `test` step fails, the `build and push` step should not proceed.

## Proposed Changes

Revert the commit for now to make sure GHA pipelines are functioning as expected. We can try this change again next week.

## Verification Steps

No verification needed, this is a revert commit so we'll bring back previous GHA pipelines behavior.


