### PR TITLE
[SHEP-92] csrf authentication error fix

### DIFF
--- a/ad-ops-dashboard/README.md
+++ b/ad-ops-dashboard/README.md
@@ -8,15 +8,6 @@ You can run this app together with the Django app in one `docker-compose up --bu
 
 Visit the React frontend at http://0.0.0.0:5173/
 
-We will need the following details to be added to settings.py in order to fix the CSRF permissions denied error for the APIs. This will be removed once CSRF authentication is implemented.
-
-```
-REST_FRAMEWORK = {
-"DEFAULT_AUTHENTICATION_CLASSES": [],
-"DEFAULT_PERMISSION_CLASSES": [],
-}
-```
-
 # Next steps
 
 Still missing from this setup:

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -261,7 +261,7 @@ markus.configure(backends=_MARKUS_BACKENDS)
 
 CORS_ALLOWED_ORIGINS = ["http://0.0.0.0:5173", "http://localhost:5173"]
 
-CSRF_TRUSTED_ORIGINS = ["http://localhost:5173"]
+CSRF_TRUSTED_ORIGINS = ["http://0.0.0.0:5173", "http://localhost:5173"]
 
 REST_FRAMEWORK: Dict[str, Any] = {
     "DEFAULT_AUTHENTICATION_CLASSES": [],

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -2,7 +2,7 @@
 
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 import environ
 import markus
@@ -259,6 +259,10 @@ if STATSD_DEBUG:
     )
 markus.configure(backends=_MARKUS_BACKENDS)
 
-CORS_ALLOWED_ORIGINS = [
-    "http://0.0.0.0:5173",
-]
+CORS_ALLOWED_ORIGINS = ["http://0.0.0.0:5173", "http://localhost:5173"]
+
+CSRF_TRUSTED_ORIGINS = ["http://localhost:5173"]
+
+REST_FRAMEWORK: Dict[str, Any] = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [],
+}


### PR DESCRIPTION
## References

[SHEP-92](https://mozilla-hub.atlassian.net/browse/SHEP-92)

## Problem Statement

CSRF authentication needs to be added for the APIs, as Django returns CSRF authentication errors on POST, PATCH, and DELETE requests.

## Proposed Changes

Added the CSRF Origins array.
Made the authentication classes empty to resolve the CSRF authentication issue since Open IDC authentication is applied.

## Verification Steps

You can test the fix by removing the empty authentication class to check csrf errors. To find out how Open IDC authentication conflicts with Django authentication, we can remove the OpenIDC authentication and use the default Django authentication classes. This should not return any CSRF-related errors.


[SHEP-92]: https://mozilla-hub.atlassian.net/browse/SHEP-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ