### PR TITLE
[SHEP-17]: Publish sync bq data docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -16,6 +16,8 @@
   - [Recover Snapshot](./operations/recoveryScript.md)
   - [Sync Data from Boostr](./operations/syncBoostrData.md)
   - [Sync Data from Boostr Cron Job](./operations/syncBoostrDataCron.md)
+  - [Sync Data from BigQuery](./operations/syncBigQueryData.md)
+  - [Sync Data from BigQuery Cron Job](./operations/syncBigQueryDataCron.md)
 
 
 # ADR


### PR DESCRIPTION
## References

[SHEP-17](https://mozilla-hub.atlassian.net/browse/SHEP-17)

## Problem Statement

New docs need to be added to our table of contents file so they show up in our [standalone doc](https://mozilla-services.github.io/consvc-shepherd/intro.html).

## Proposed Changes

- Add Sync BQ Data documentation to table of contents

## Verification Steps

- Run the docs locally (follow doc make targets in our Makefile) and you should see two new Sync BQ data docs showing up [here](https://mozilla-services.github.io/consvc-shepherd/operations/index.html)


[SHEP-17]: https://mozilla-hub.atlassian.net/browse/SHEP-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Visuals

![image](https://github.com/user-attachments/assets/c43ec91e-b36c-4076-8502-42715bcab57d)
