### PR TITLE
[SHEP-17] - Add a default project-id to BQ sync script

### DIFF
--- a/consvc_shepherd/management/commands/sync_bq_data.py
+++ b/consvc_shepherd/management/commands/sync_bq_data.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
             "--project_id",
             default=DEFAULT_PROJECT_ID,
             type=str,
-            help="The GCP project ID that will interact with BQ. By default, it will use \"moz-fx-ads-prod\"",
+            help='The GCP project ID that will interact with BQ. By default, it will use "moz-fx-ads-prod"',
         )
         parser.add_argument(
             "--date",

--- a/consvc_shepherd/management/commands/sync_bq_data.py
+++ b/consvc_shepherd/management/commands/sync_bq_data.py
@@ -14,6 +14,7 @@ from consvc_shepherd.models import BQSyncStatus, DeliveredFlight
 
 SYNC_STATUS_SUCCESS = "success"
 SYNC_STATUS_FAILURE = "failure"
+DEFAULT_PROJECT_ID = "moz-fx-ads-prod"
 
 
 class Command(BaseCommand):
@@ -25,8 +26,9 @@ class Command(BaseCommand):
         """Register expected command line arguments"""
         parser.add_argument(
             "--project_id",
+            default=DEFAULT_PROJECT_ID,
             type=str,
-            help="The GCP project ID that will interact with BQ, e.g. moz-fx-ads-nonprod.",
+            help="The GCP project ID that will interact with BQ. By default, it will use \"moz-fx-ads-prod\"",
         )
         parser.add_argument(
             "--date",


### PR DESCRIPTION
## References

[SHEP-17](https://mozilla-hub.atlassian.net/browse/SHEP-17)

## Problem Statement

[Andre suggested](https://github.com/mozilla-it/webservices-infra/pull/2900#discussion_r1797262801) it would be easier to configure the infra side if the script handled the project-id logic (instead of configuring the k8s job to use that info).

## Proposed Changes
- Use  a default project id `moz-fx-ads-prod` to query BQ
- Add tests for the default project id

## Verification Steps

- Run shepherd and exec with `make debug`
- Run the script without providing a project ID with  `python manage.py sync_bq_data` and check that the script runs successfully.
- Try passing a different project id with ``python manage.py sync_bq_data --project_id "moz-fx-ads-nonprod"` and check that the script runs successfully
- Run the tests


[SHEP-17]: https://mozilla-hub.atlassian.net/browse/SHEP-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ