### PR TITLE
[SHEP-36]: Adding make command to show human readable timestamps in local docker logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ doc-preview: doc  ##  Preview Merino docs via the default browser
 dev: $(INSTALL_STAMP)  ##  Run shepherd locally and reload automatically
 	docker compose up
 
+dev-ts: $(INSTALL_STAMP)  ##  Run shepherd locally and show human readable timestamps.
+	docker-compose up -d && docker-compose logs -f -t
+
 local-test-django: $(INSTALL_STAMP) # Run shepherd Django app tests locally
 	docker compose -f docker-compose.test-django.yml up --abort-on-container-exit
 


### PR DESCRIPTION
## References

[SHEP-32](https://mozilla-hub.atlassian.net/browse/SHEP-32)

## Problem Statement

The original ask was to modify the timestamp in the log outputs to display in a more human readable format to allow for easier local debugging as by default, docker logs in the command line do not show human readable timestamps. (They do in Docker Desktop however, but this is not as convenient.)

## Proposed Changes

The [JSON formatting library](https://python-dockerflow.readthedocs.io/en/main/api/logging.html) we are using for logging very strictly conforms to the [MozLog schema](https://wiki.mozilla.org/Firefox/Services/Logging). As a result, we cannot easily modify the timestamp field to be in a different format.

However, to achieve the same goal of making local dev logs more clear, we can make some changes to how we run our docker containers and add a new make command `dev-ts` that will display timestamps next to all docker logs. This however does come with a downside that we have to run `docker-compose up` in detached mode, meaning the usual `ctrl-c` motion will simply close out of the log follower, not kill the containers. 

## Verification Steps

- [ ] Pull down new changes
- [ ] run `make dev-ts`
- [ ] Verify human-readable timestamps are visible next to logs.

## Visuals
New behavior with `make dev-ts` command.
![Screenshot 2024-10-15 at 5 55 05 PM](https://github.com/user-attachments/assets/e6ebc735-5f2c-415e-ad90-4e5556e8230f)



[SHEP-32]: https://mozilla-hub.atlassian.net/browse/SHEP-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ