### PR TITLE
[SHEP-137] Tune jest config for CI, local testing, and watch mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ test-django: local-migration-check # Run the tests for the shepherd Django app i
 	env DJANGO_SETTINGS_MODULE=consvc_shepherd.settings $(POETRY) run pytest --cov --cov-report=term-missing --cov-fail-under=$(COV_FAIL_UNDER)
 
 test-react: # Run the tests for the ad-ops-dashboard React app in CI
-	cd ad-ops-dashboard && npm run test
+	cd ad-ops-dashboard && npm run test:ci
 
 test: test-django test-react  ##  Run all tests in CI
 
@@ -97,7 +97,7 @@ doc: ##  Generate docs via mdBook
 doc-preview: doc  ##  Preview Merino docs via the default browser
 	mdbook serve --open
 
-dev: $(INSTALL_STAMP)  ## Run shepherd locally and show human readable timestamps.  
+dev: $(INSTALL_STAMP)  ## Run shepherd locally and show human readable timestamps.
 	docker-compose up -d && docker-compose logs -f -t
 
 local-test-django: $(INSTALL_STAMP) # Run shepherd Django app tests locally

--- a/ad-ops-dashboard/jest.config.js
+++ b/ad-ops-dashboard/jest.config.js
@@ -7,21 +7,20 @@ export default {
     "!src/**/*.d.ts",
     "!src/__mocks__/**",
   ],
-  coverageDirectory:"coverage",
-  coverageReporters: ['text', 'lcov', "text-summary"],
-  // Not ready for this yet, but let's get there soon
+  coverageDirectory: "coverage",
+  coverageReporters: ["text", "lcov", "text-summary"],
   coverageThreshold: {
     global: {
       lines: 80,
-      statements:80,
+      statements: 80,
     },
   },
   testEnvironment: "jest-fixed-jsdom",
   testEnvironmentOptions: {
-    customExportConditions: [''],
+    customExportConditions: [""],
   },
   modulePaths: ["<rootDir>/src"],
-  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  setupFilesAfterEnv: ["<rootDir>/src/setupTests.ts"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",
@@ -60,4 +59,5 @@ export default {
     "node",
   ],
   resetMocks: true,
+  maxWorkers: "50%",
 };

--- a/ad-ops-dashboard/package.json
+++ b/ad-ops-dashboard/package.json
@@ -13,7 +13,8 @@
     "lint": "npx eslint .",
     "lint:fix": "npm run lint -- --fix",
     "preview": "vite preview",
-    "test": "NODE_ENV=test jest --coverage"
+    "test": "NODE_ENV=test jest --coverage",
+    "test:ci": "NODE_ENV=test jest --coverage --runInBand"
   },
   "dependencies": {
     "@emotion/react": "^11.13.3",

--- a/ad-ops-dashboard/package.json
+++ b/ad-ops-dashboard/package.json
@@ -14,7 +14,8 @@
     "lint:fix": "npm run lint -- --fix",
     "preview": "vite preview",
     "test": "NODE_ENV=test jest --coverage",
-    "test:ci": "NODE_ENV=test jest --coverage --runInBand"
+    "test:ci": "NODE_ENV=test jest --coverage --runInBand",
+    "test:watch": "jest --watch --coverage --maxWorkers=25%"
   },
   "dependencies": {
     "@emotion/react": "^11.13.3",


### PR DESCRIPTION
## References

[SHEP-137](https://mozilla-hub.atlassian.net/browse/SHEP-137)

## Problem Statement

We have been seeing [an error pop up in CI](https://app.circleci.com/pipelines/github/mozilla-services/consvc-shepherd/1568/workflows/93d616ab-aa3f-4361-8dbd-8bcc5e5a1618/jobs/4925) when running the jest tests, "A jest worker process was terminated by another process". The issue is coming from the fact that jest's default behavior is spinning up a worker pool to run tests, with as many workers as there are cores on the machine, which doesn't work in CI.

## Proposed Changes

Spinning up this worker pool itself has performance costs, and its better to tune the jest config for almost all cases. For local development, it's better to set the workers to a relative value (50%). For CI, it's better to run in serial instead of spin up workers (`--runInBand`). For watch model, it's best to use even less workers on the machine (25%).

## Verification Steps

You can see the simultaneous CI runs for this branch and it's siblings. 5 simultaneous runs didn't trigger the error, so I figure this is already an improvement.

Please double check that
- In CI, we're running new command `npm run test:ci` and this command uses the `--runInBand` flag
- Locally, `make local-test` still works as expected
- Locally, New command `npm run test:watch` works as expected


[SHEP-137]: https://mozilla-hub.atlassian.net/browse/SHEP-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ