### PR TITLE
[SHEP-36] Adding additional flexibility to local logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 DEBUG=true
-APP_ENV=dev
+CUSTOM_LOCAL_LOGGER_ENABLED=false
 SHEPHERD_ENV=INFO
 SECRET_KEY=keyboard-mash
 DB_NAME=postgres

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ doc: ##  Generate docs via mdBook
 doc-preview: doc  ##  Preview Merino docs via the default browser
 	mdbook serve --open
 
-dev: $(INSTALL_STAMP)  ## Run shepherd locally and show human readable timestamps.  
+dev: $(INSTALL_STAMP)  ## Run shepherd locally and show human readable timestamps.
 	docker compose up -d && docker-compose logs -f -t
 
 local-test-django: $(INSTALL_STAMP) # Run shepherd Django app tests locally

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ doc-preview: doc  ##  Preview Merino docs via the default browser
 	mdbook serve --open
 
 dev: $(INSTALL_STAMP)  ## Run shepherd locally and show human readable timestamps.  
-	docker-compose up -d && docker-compose logs -f -t
+	docker compose up -d && docker-compose logs -f -t
 
 local-test-django: $(INSTALL_STAMP) # Run shepherd Django app tests locally
 	docker compose -f docker-compose.test-django.yml up --abort-on-container-exit

--- a/consvc_shepherd/management/commands/sync_boostr_data.py
+++ b/consvc_shepherd/management/commands/sync_boostr_data.py
@@ -95,12 +95,10 @@ class BoostrApi:
     session: requests.Session
     log: logging.Logger
 
-    def __init__(
-        self, base_url: str, email: str, password: str, options=DEFAULT_OPTIONS
-    ):
+    def __init__(self, base_url: str, email: str, password: str, options=DEFAULT_OPTIONS):
+        self.log = logging.getLogger("sync_boostr_data")
         self.base_url = base_url
         self.setup_session(email, password)
-        self.log = logging.getLogger("sync_boostr_data")
 
     def setup_session(self, email: str, password: str) -> None:
         """Authenticate with the boostr api and create and store a session on the instance"""
@@ -132,20 +130,13 @@ class BoostrApi:
         )
 
         if response.status_code == HTTP_TOO_MANY_REQUESTS:
-            retry_after = (
-                int(response.headers.get("Retry-After", default=DEFAULT_RETRY_INTERVAL))
-                + 1
-            )
-            self.log.info(
-                f"{response.status_code}: Rate Limited - Waiting {retry_after} seconds"
-            )
+            retry_after = int(response.headers.get("Retry-After", default=DEFAULT_RETRY_INTERVAL)) + 1
+            self.log.info(f"{response.status_code}: Rate Limited - Waiting {retry_after} seconds")
             self._sleep(retry_after)
             return self.post(path, json, headers)
 
         if not response.ok:
-            raise BoostrApiError(
-                f"Bad response status {response.status_code} from /{path}: {response}"
-            )
+            raise BoostrApiError(f"Bad response status {response.status_code} from /{path}: {response}")
         json = response.json()
         return json
 
@@ -162,17 +153,13 @@ class BoostrApi:
                     timeout=15,
                 )
             except requests.exceptions.RequestException as e:
-                self.log.info(
-                    f"RequestException occurred: {e}. Current retry: {current_retry}"
-                )
+                self.log.info(f"RequestException occurred: {e}. Current retry: {current_retry}")
                 current_retry += 1
                 self._sleep(DEFAULT_RETRY_INTERVAL)
                 continue
 
             if response.status_code == HTTP_TOO_MANY_REQUESTS:
-                retry_after = (
-                    int(response.headers.get("Retry-After", DEFAULT_RETRY_INTERVAL)) + 1
-                )
+                retry_after = int(response.headers.get("Retry-After", DEFAULT_RETRY_INTERVAL)) + 1
                 self.log.info(
                     f"{response.status_code}: Rate limited - Waiting {retry_after} seconds. "
                     f"Current retry: {current_retry}"
@@ -185,9 +172,7 @@ class BoostrApi:
                 json = response.json()
                 return json
             else:
-                raise BoostrApiError(
-                    f"Bad response status {response.status_code} from /{path}"
-                )
+                raise BoostrApiError(f"Bad response status {response.status_code} from /{path}")
 
         raise BoostrApiMaxRetriesError("Maximum retries reached")
 
@@ -204,16 +189,12 @@ class BoostrLoader:
     max_deal_pages: int
     full_sync: bool
 
-    def __init__(
-        self, base_url: str, email: str, password: str, options=DEFAULT_OPTIONS
-    ):
+    def __init__(self, base_url: str, email: str, password: str, options=DEFAULT_OPTIONS):
         self.log = logging.getLogger("sync_boostr_data")
         self.boostr = BoostrApi(base_url, email, password, options)
         self.max_deal_pages = options.get("max_deal_pages", MAX_DEAL_PAGES_DEFAULT)
         self.full_sync = options.get("full_sync", FULL_SYNC)
-        self.latest_synced_on = (
-            self.get_latest_sync_status() if not self.full_sync else None
-        )
+        self.latest_synced_on = self.get_latest_sync_status() if not self.full_sync else None
 
     def upsert_products(self) -> None:
         """Fetch all Boostr products and upsert them to Shepherd DB"""
@@ -285,9 +266,7 @@ class BoostrLoader:
                         "advertiser_id": advertiser,
                         "currency": deal["currency"],
                         "amount": math.floor(float(deal["budget"])),
-                        "sales_representatives": ",".join(
-                            str(d["email"]) for d in deal["deal_members"]
-                        ),
+                        "sales_representatives": ",".join(str(d["email"]) for d in deal["deal_members"]),
                         "start_date": deal["start_date"],
                         "end_date": deal["end_date"],
                     },
@@ -302,9 +281,7 @@ class BoostrLoader:
                 self.log.info(f"Upserted products and budgets for deal: {deal['id']}")
             # If this is the last iteration of the loop due to the max page limit, log that we stopped
             if page >= self.max_deal_pages:
-                self.log.info(
-                    f"Done. Stopped fetching deals after hitting max_page_limit of {page} pages."
-                )
+                self.log.info(f"Done. Stopped fetching deals after hitting max_page_limit of {page} pages.")
 
     def create_campaign(self, deal: BoostrDeal) -> None:
         """Create campaign if a boostr deal is created. Returns True if successful, False otherwise."""
@@ -328,13 +305,9 @@ class BoostrLoader:
             else {}
         )
 
-        deal_products = self.boostr.get(
-            f"deals/{deal.boostr_id}/deal_products", params=deal_products_params
-        )
+        deal_products = self.boostr.get(f"deals/{deal.boostr_id}/deal_products", params=deal_products_params)
 
-        self.log.debug(
-            f"Fetched {len(deal_products)} deal_products for deal: {deal.boostr_id}"
-        )
+        self.log.debug(f"Fetched {len(deal_products)} deal_products for deal: {deal.boostr_id}")
 
         for deal_product in deal_products:
             product = BoostrProduct.objects.get(boostr_id=deal_product["product"]["id"])
@@ -362,15 +335,11 @@ class BoostrLoader:
         """Retrieve the lastest successful boostr sync status from the DB"""
         success_syncs = BoostrSyncStatus.objects.filter(status=SYNC_STATUS_SUCCESS)
         if not len(success_syncs):
-            self.log.info(
-                "Unable to retrieve the latest successful boost sync status record"
-            )
+            self.log.info("Unable to retrieve the latest successful boost sync status record")
             return None
 
         sync_status = success_syncs.latest("synced_on")
-        self.log.info(
-            f"Fetched latest sync status: {sync_status.pk}, synced_on: {sync_status.synced_on}"
-        )
+        self.log.info(f"Fetched latest sync status: {sync_status.pk}, synced_on: {sync_status.synced_on}")
         return sync_status.synced_on
 
     def load(self):
@@ -378,22 +347,14 @@ class BoostrLoader:
         try:
             sync_start_time = timezone.now() + timedelta(hours=1)
 
-            self.log.info(
-                f"Starting Boostr sync at {sync_start_time} retrieving records >= {self.latest_synced_on}"
-            )
+            self.log.info(f"Starting Boostr sync at {sync_start_time} retrieving records >= {self.latest_synced_on}")
             self.upsert_products()
             self.upsert_deals()
-            self.log.info(
-                "Boostr sync process completed successfully. Updating sync_status"
-            )
-            self.update_sync_status(
-                SYNC_STATUS_SUCCESS, sync_start_time, "Boostr sync success"
-            )
+            self.log.info("Boostr sync process completed successfully. Updating sync_status")
+            self.update_sync_status(SYNC_STATUS_SUCCESS, sync_start_time, "Boostr sync success")
         except Exception as e:
             error = f"Exception: {str(e):} Trace: {traceback.format_exc()}"
-            self.log.error(
-                f"Boostr sync process encountered an error: {error}. Updating sync_status"
-            )
+            self.log.error(f"Boostr sync process encountered an error: {error}. Updating sync_status")
             self.update_sync_status(
                 SYNC_STATUS_FAILURE,
                 sync_start_time,

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -176,9 +176,7 @@ STORAGES: dict[str, Any] = {
 GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME", default="settings_from_shepherd")
 ALLOCATION_FILE_NAME: str = env("ALLOCATION_FILE_NAME", default="allocation_file")
 
-_console_formatter = (
-    "localdev" if bool(env("CUSTOM_LOCAL_LOGGER_ENABLED", default="false")) else "json"
-)
+_console_formatter = "localdev" if env("CUSTOM_LOCAL_LOGGER_ENABLED", default=False) else "json"
 
 LOGGING: dict[str, Any] = {
     "version": 1,

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -176,7 +176,9 @@ STORAGES: dict[str, Any] = {
 GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME", default="settings_from_shepherd")
 ALLOCATION_FILE_NAME: str = env("ALLOCATION_FILE_NAME", default="allocation_file")
 
-_console_formatter = "localdev" if env("CUSTOM_LOCAL_LOGGER_ENABLED", default=False) else "json"
+_console_formatter = (
+    "localdev" if env("CUSTOM_LOCAL_LOGGER_ENABLED", default=False) else "json"
+)
 
 LOGGING: dict[str, Any] = {
     "version": 1,

--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -176,16 +176,37 @@ STORAGES: dict[str, Any] = {
 GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME", default="settings_from_shepherd")
 ALLOCATION_FILE_NAME: str = env("ALLOCATION_FILE_NAME", default="allocation_file")
 
+_console_formatter = (
+    "localdev" if bool(env("CUSTOM_LOCAL_LOGGER_ENABLED", default="false")) else "json"
+)
+
 LOGGING: dict[str, Any] = {
     "version": 1,
     "formatters": {
-        "json": {"()": "dockerflow.logging.JsonLogFormatter", "logger_name": "shepherd"}
+        # For any custom local logging that you do not what included in prod, modify this formatter.
+        "localdev": {
+            "format": "".join(
+                [
+                    "{levelname} {{",
+                    "Timestamp: {asctime}, ",
+                    "Type: {module}, ",
+                    "Logger: shepherd, ",
+                    "Message: '{message}', ",
+                    "Pid: {process}}}",
+                ]
+            ),
+            "style": "{",
+        },
+        "json": {
+            "()": "dockerflow.logging.JsonLogFormatter",
+            "logger_name": "shepherd",
+        },
     },
     "handlers": {
         "console": {
             "level": env("SHEPHERD_ENV", default="DEBUG"),
             "class": "logging.StreamHandler",
-            "formatter": "json",
+            "formatter": _console_formatter,
             "stream": sys.stdout,
         },
     },

--- a/manage.py
+++ b/manage.py
@@ -1,24 +1,9 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
-from argparse import OPTIONAL
-import os
 import sys
-import logging
-import environ
-
-from pathlib import Path
-
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "consvc_shepherd.settings")
-    env = environ.Env(APP_ENV=(str, OPTIONAL))
-    BASE_DIR = Path(__file__).resolve().parent.parent
-    environ.Env.read_env(BASE_DIR / ".env")
-    
-    # For local dev, human readable timestamps are added to help with debugging.
-    if env("APP_ENV") == "dev":
-        logging.basicConfig(format="%(asctime)s.%(msecs)03d", level=logging.INFO, datefmt="%Y-%m-%d,%H:%M:%S")
 
     try:
         from django.core.management import execute_from_command_line


### PR DESCRIPTION
## References

[SHEP-36](https://mozilla-hub.atlassian.net/browse/SHEP-36)

## Problem Statement

After speaking with @mashalifshin it sounds like we wanted to expand on this ticket to include an entire custom local logging formatted. This will allow us to not only add human readable timestamps, but also allow for us, in the future, to have more verbose, "local specific" logging that can help with debugging.

## Proposed Changes

We've added a new formatter called `localdev` to `settings.py` file. This is enabled when the env variable `CUSTOM_LOCAL_LOGGER_ENABLED` is set to true and disabled by default or when explicitly set to false. This new logging formatter will display most of the fields similar to the JSON logger with some small changes.

1. The log level has been moved to a header and in human readable format (rather than a number value)
2. The timestamp has been changed to be in human-readable format rather than UNIX ns. 

We've also gone ahead and removed the `APP_ENV` variable as this new flag is much clearer as to the intent.

## Additional Changes

I noticed a bug in running the sync_boostr script. It seems like if the rate limit has been hit, the app will fail on startup due to the fact the `log` object is initialized _after_ the first call to the APIs are made. As a result, I've moved the declaration of the logger to the first line of the init. Seeing as this is still related to logging I've included it in this ticket but happy to make it a new ticket if people prefer. 

## Verification Steps

1. Pull down this branch and run the local script as you normally would. You should see no changes to the standard logging behavior of the application.
2. Add a new `.env` variable: `CUSTOM_LOCAL_LOGGER_ENABLED=true`.
4. Run the script normally and verify the logs now appear to be in the form `INFO {Timestamp: 2024-10-22 15:40:55,256, Type: sync_boostr_data, Logger: shepherd, Message: 'Upserted products and budgets for deal: 435629', Pid: 42}`

## Visuals

Example of the logging format with this new flag set to true.
![Screenshot 2024-10-22 at 8 41 07 AM](https://github.com/user-attachments/assets/71cb5ba1-8027-425a-ac39-ca8d457a6954)



[SHEP-36]: https://mozilla-hub.atlassian.net/browse/SHEP-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ