### PR TITLE
[Shep 123] - Enabling Sentry for React frontend of ad-ops-dashboard

### DIFF
--- a/ad-ops-dashboard/package-lock.json
+++ b/ad-ops-dashboard/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^6.1.0",
         "@mui/styles": "^6.1.0",
         "@mui/x-date-pickers": "^7.17.0",
+        "@sentry/react": "^8.35.0",
         "@tanstack/react-query": "^5.55.4",
         "ag-grid-react": "^32.1.0",
         "axios": "^1.7.7",
@@ -3176,6 +3177,135 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.35.0.tgz",
+      "integrity": "sha512-uj9nwERm7HIS13f/Q52hF/NUS5Al8Ma6jkgpfYGeppYvU0uSjPkwMogtqoJQNbOoZg973tV8qUScbcWY616wNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.35.0",
+        "@sentry/types": "8.35.0",
+        "@sentry/utils": "8.35.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.35.0.tgz",
+      "integrity": "sha512-7bjSaUhL0bDArozre6EiIhhdWdT/1AWNWBC1Wc5w1IxEi5xF7nvF/FfvjQYrONQzZAI3HRxc45J2qhLUzHBmoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.35.0",
+        "@sentry/types": "8.35.0",
+        "@sentry/utils": "8.35.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.35.0.tgz",
+      "integrity": "sha512-3wkW03vXYMyWtTLxl9yrtkV+qxbnKFgfASdoGWhXzfLjycgT6o4/04eb3Gn71q9aXqRwH17ISVQbVswnRqMcmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.35.0",
+        "@sentry/core": "8.35.0",
+        "@sentry/types": "8.35.0",
+        "@sentry/utils": "8.35.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.35.0.tgz",
+      "integrity": "sha512-TUrH6Piv19kvHIiRyIuapLdnuwxk/Un/l1WDCQfq7mK9p1Pac0FkQ7Uufjp6zY3lyhDDZQ8qvCS4ioCMibCwQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "8.35.0",
+        "@sentry/core": "8.35.0",
+        "@sentry/types": "8.35.0",
+        "@sentry/utils": "8.35.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.35.0.tgz",
+      "integrity": "sha512-WHfI+NoZzpCsmIvtr6ChOe7yWPLQyMchPnVhY3Z4UeC70bkYNdKcoj/4XZbX3m0D8+71JAsm0mJ9s9OC3Ue6MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.35.0",
+        "@sentry-internal/feedback": "8.35.0",
+        "@sentry-internal/replay": "8.35.0",
+        "@sentry-internal/replay-canvas": "8.35.0",
+        "@sentry/core": "8.35.0",
+        "@sentry/types": "8.35.0",
+        "@sentry/utils": "8.35.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.35.0.tgz",
+      "integrity": "sha512-Ci0Nmtw5ETWLqQJGY4dyF+iWh7PWKy6k303fCEoEmqj2czDrKJCp7yHBNV0XYbo00prj2ZTbCr6I7albYiyONA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "8.35.0",
+        "@sentry/utils": "8.35.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.35.0.tgz",
+      "integrity": "sha512-8Y+s4pE9hvT2TwSo5JS/Enw2cNFlwiLcJDNGCj/Hho+FePFYA59hbN06ouTHWARnO+swANHKZQj24Wp57p1/tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "8.35.0",
+        "@sentry/core": "8.35.0",
+        "@sentry/types": "8.35.0",
+        "@sentry/utils": "8.35.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.35.0.tgz",
+      "integrity": "sha512-AVEZjb16MlYPifiDDvJ19dPQyDn0jlrtC1PHs6ZKO+Rzyz+2EX2BRdszvanqArldexPoU1p5Bn2w81XZNXThBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.35.0.tgz",
+      "integrity": "sha512-MdMb6+uXjqND7qIPWhulubpSeHzia6HtxeJa8jYI09OCvIcmNGPydv/Gx/LZBwosfMHrLdTWcFH7Y7aCxrq7cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "8.35.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",

--- a/ad-ops-dashboard/package.json
+++ b/ad-ops-dashboard/package.json
@@ -25,6 +25,7 @@
     "@mui/material": "^6.1.0",
     "@mui/styles": "^6.1.0",
     "@mui/x-date-pickers": "^7.17.0",
+    "@sentry/react": "^8.35.0",
     "@tanstack/react-query": "^5.55.4",
     "ag-grid-react": "^32.1.0",
     "axios": "^1.7.7",

--- a/ad-ops-dashboard/src/App.tsx
+++ b/ad-ops-dashboard/src/App.tsx
@@ -1,7 +1,8 @@
+import { sentryCreateBrowserRouter } from "./instrument.tsx"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-quartz.css";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { RouterProvider } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { routes } from "./routes.tsx";
@@ -16,7 +17,8 @@ const queryClient = new QueryClient({
   },
 });
 
-const router = createBrowserRouter(routes);
+
+const router = sentryCreateBrowserRouter(routes);
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -26,5 +28,7 @@ export default function App() {
         <RouterProvider router={router} />
       </Suspense>
     </QueryClientProvider>
+
+
   );
 }

--- a/ad-ops-dashboard/src/components/Errors/DefaultError.tsx
+++ b/ad-ops-dashboard/src/components/Errors/DefaultError.tsx
@@ -1,0 +1,17 @@
+import { useRouteError } from "react-router-dom";
+import * as Sentry from "@sentry/react";
+import { useEffect } from "react";
+
+export function DefaultError() {
+  const error = useRouteError() as Error;
+
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div>
+      <h1> :( This is the default error page. </h1>
+    </div>
+  );
+}

--- a/ad-ops-dashboard/src/instrument.tsx
+++ b/ad-ops-dashboard/src/instrument.tsx
@@ -11,7 +11,6 @@ import {
 
 
 const isLocal = process.env.NODE_ENV === 'development';
-console.log(process.env.SENTRY_DSN)
 const options: Sentry.BrowserOptions = {
   dsn: process.env.VITE_SENTRY_DSN,
   integrations: [

--- a/ad-ops-dashboard/src/instrument.tsx
+++ b/ad-ops-dashboard/src/instrument.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+import * as Sentry from "@sentry/react";
+
+import {
+  createBrowserRouter,
+  createRoutesFromChildren,
+  matchRoutes,
+  useLocation,
+  useNavigationType,
+} from "react-router-dom";
+
+
+const isLocal = process.env.NODE_ENV === 'development';
+console.log(process.env.SENTRY_DSN)
+const options: Sentry.BrowserOptions = {
+  dsn: process.env.VITE_SENTRY_DSN,
+  integrations: [
+    // See docs for support of different versions of variation of react router
+    // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/
+    Sentry.reactRouterV6BrowserTracingIntegration({
+      useEffect: useEffect,
+      useLocation,
+      useNavigationType,
+      createRoutesFromChildren,
+      matchRoutes,
+    }),
+    Sentry.browserTracingIntegration(),
+  ],
+  environment: process.env.NODE_ENV,
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for tracing.
+  tracesSampleRate: 1.0,
+}
+
+// Log sentry events to the console, not sentry when on local dev
+if (isLocal) {
+  options.beforeSend = (event: Sentry.ErrorEvent) => {
+    console.log('Sentry Event:', event); // Log the event for testing
+    return null; // Prevent sending to real sentry
+  }
+}
+
+Sentry.init(options)
+
+
+export const sentryCreateBrowserRouter = Sentry.wrapCreateBrowserRouter(
+  createBrowserRouter,
+);

--- a/ad-ops-dashboard/src/pages/Debug/Debug.tsx
+++ b/ad-ops-dashboard/src/pages/Debug/Debug.tsx
@@ -1,6 +1,7 @@
 
 import * as Sentry from "@sentry/react";
 import { useEffect, useState } from "react";
+import Page404 from "../Page404";
 export default function Debug() {
 
   const [isPageBroken, setIsPageBroken] = useState(false)
@@ -22,24 +23,33 @@ export default function Debug() {
     }
   }
 
-  return (
-    <div style={{ textAlign: "center", padding: 20 }}>    <h1> Debug pannel </h1>
-      <div style={{ display: "flex", gap: 20, justifyContent: "center" }}>
-        <button
-          type="button"
-          onClick={makeError}> Throw caught sentry error
-        </button>
-        <button
-          type="button"
-          onClick={() => { setErrorCount(1); }}> Break useEffect
-        </button>
-        <button
-          type="button"
-          onClick={() => { setIsPageBroken(true); }}> Break Page
-        </button>
+  if (process.env.NODE_ENV === "development") {
+    return (
+      <div style={{ textAlign: "center", padding: 20 }}>
+        <div>
+          <h2> Debug pannel! (Dev Env Only) </h2>
+          <p>Include any buttons here that force certain actions or frontend states. This page is only visible running `npm run dev` and cannot be viewed in production builds</p>
+        </div>
+        <div style={{ display: "flex", paddingTop: 20, gap: 20, justifyContent: "center" }}>
+          <button
+            type="button"
+            onClick={makeError}> Throw caught sentry error
+          </button>
+          <button
+            type="button"
+            onClick={() => { setErrorCount(1); }}> Break useEffect
+          </button>
+          <button
+            type="button"
+            onClick={() => { setIsPageBroken(true); }}> Break Page
+          </button>
+        </div>
+        { /* eslint-disable-next-line */}
+        <div> {isPageBroken && <ErrorComponent />} </div>
       </div>
-      { /* eslint-disable-next-line */}
-      <div> {isPageBroken && <ErrorComponent />} </div>
-    </div>
-  )
+    )
+  } else {
+    return < Page404 />
+  }
+
 } 

--- a/ad-ops-dashboard/src/pages/Debug/Debug.tsx
+++ b/ad-ops-dashboard/src/pages/Debug/Debug.tsx
@@ -1,0 +1,45 @@
+
+import * as Sentry from "@sentry/react";
+import { useEffect, useState } from "react";
+export default function Debug() {
+
+  const [isPageBroken, setIsPageBroken] = useState(false)
+  const [errorCount, setErrorCount] = useState(0)
+
+  useEffect(() => {
+    if (errorCount > 0) {
+      throw new Error("Use effect errored!")
+    }
+
+  }, [errorCount]
+  )
+
+  const makeError = () => {
+    try {
+      throw new Error("Uh oh! We did an error!")
+    } catch (err) {
+      Sentry.captureException(err);
+    }
+  }
+
+  return (
+    <div style={{ textAlign: "center", padding: 20 }}>    <h1> Debug pannel </h1>
+      <div style={{ display: "flex", gap: 20, justifyContent: "center" }}>
+        <button
+          type="button"
+          onClick={makeError}> Throw caught sentry error
+        </button>
+        <button
+          type="button"
+          onClick={() => { setErrorCount(1); }}> Break useEffect
+        </button>
+        <button
+          type="button"
+          onClick={() => { setIsPageBroken(true); }}> Break Page
+        </button>
+      </div>
+      { /* eslint-disable-next-line */}
+      <div> {isPageBroken && <ErrorComponent />} </div>
+    </div>
+  )
+} 

--- a/ad-ops-dashboard/src/routes.tsx
+++ b/ad-ops-dashboard/src/routes.tsx
@@ -2,6 +2,8 @@ import Dashboard from "./pages/Dashboard/Dashboard";
 import CampaignOverview from "./pages/CampaignOverview/CampaignOverview";
 import Page404 from "./pages/Page404";
 import Layout from "./components/Layout/AppLayout";
+import Debug from "./pages/Debug/Debug";
+import { DefaultError } from "./components/Errors/DefaultError";
 
 export const routes = [
   {
@@ -11,6 +13,7 @@ export const routes = [
       { index: true, element: <Dashboard /> },
       { path: "campaign", element: <CampaignOverview /> },
       { path: "*", element: <Page404 /> },
+      { path: "debug", element: <Debug />, errorElement: <DefaultError /> }
     ],
   },
 ];

--- a/ad-ops-dashboard/vite.config.ts
+++ b/ad-ops-dashboard/vite.config.ts
@@ -1,14 +1,29 @@
-import { defineConfig } from "vite";
+
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    host: true,
-    strictPort: true,
-    port: 5173,
-    watch: {
-      usePolling: true,
+export default defineConfig(({ mode }) => {
+  // Load environment variables based on the mode (development, production, etc.)
+  const env = loadEnv(mode, process.cwd());
+
+  return {
+    plugins: [
+      react(),
+    ],
+    server: {
+      host: true,
+      strictPort: true,
+      port: 5173,
+      watch: {
+        usePolling: true,
+      },
     },
-  },
+    define: {
+      'process.env': {
+        NODE_ENV: JSON.stringify(env.VITE_NODE_ENV),
+        SENTRY_DSN: JSON.stringify(env.VITE_SENTRY_DSN)
+
+      },
+    },
+  };
 });


### PR DESCRIPTION
## References

[SHEP-123](https://mozilla-hub.atlassian.net/browse/SHEP-123)

## Problem Statement

In this ticket we aim to enable sentry for our [React frontend](https://docs.sentry.io/platforms/javascript/guides/react/). This will allow better logging, visibility, and handling of browser-side errors that might occur for the user.

## Proposed Changes

In this PR, we've followed the above docs _mostly_ but had to make a few modifications in order to have things work with `react-router`. Information regarding this integration can be found [here](https://docs.sentry.io/platforms/javascript/guides/react/features/react-router/)

At a high level, the following changes were made in this PR:

1. A new `instruments.tsx` file which contains the `Sentry.init()` as well as configuration options, and the definition and export of a `sentryCreateBrowserRouter` wrapper for the `react-router` package.
2. We've modified the `App.tsx` file to use this new `sentryCreateBrowserRouter` wrapper for our routes. This operates the same as it did previously, but allows us to handle error boundaries without react-router "eating" the errors before Sentry can see them.
3. We've modified the `vite-config.ts` file in order to surface the `NODE_ENV` environment variable. This is a really useful env variable that allows us to lock certain features behind dev only mode. (dev mode is only enabled when running the app through `npm run dev`. Productions builds will have this set to NODE_ENV='production')
4. In order to keep Sentry from logging errors in local dev, we've added a check for this env variable and an override in our Sentry Options to log simply console log the Sentry event rather than push it to Sentry.
5. A new "DefaultError" component was created as a placeholder for any default error page we might want. For now I'm just including something so we can test the Sentry error boundaries. 

In addition, I've added an extra route `/debug` which is only accessible in dev mode. In any production build, this will throw a 404. I've done this in the past for my frontends and it's been really useful to add different buttons that can force some state easily in the application. For example, here we are using it to test the sentry error boundaries and sentry logging by having buttons that force certain failure states. Let me know if folks like this.

## Verification Steps

- [ ] Install all new dependencies
- [ ] run the app using `npm run dev` or whatever other dev entry point you'd like
- [ ] navigate to `/debug` (Verify this is does not 404)
- [ ] Open the browser console and verify a sentry event is created when the first button `Throw caught sentry error` is hit.
- [ ] Press `Break useEffect` and verify a sentry event is logged, and the page gracefully fails over to the DefaultError component.
- [ ] Go back to `/debug` and verify the last button `Break Page` does the same. (These last two steps are two different failure modes. One where a `useEffect` call fails and another where the `JSX` enters an invalid state)
- [ ] Finally create a local production build of the app using `npm run build` followed by `npm run start` (you may have to close any docker containers you have running)
- [ ] Re-open the fronted in the browser and check `/debug` throws a 404.


## Visuals

If applicable, provide screenshots or videos here with the expected new behavior. If not, please remove this section.
