### PR TITLE
[SHEP-36] Hotfix for failing script in staging.

### DIFF
--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -175,10 +175,9 @@ STORAGES: dict[str, Any] = {
 
 GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME", default="settings_from_shepherd")
 ALLOCATION_FILE_NAME: str = env("ALLOCATION_FILE_NAME", default="allocation_file")
+CUSTOM_LOCAL_LOGGER_ENABLED: bool = env("CUSTOM_LOCAL_LOGGER_ENABLED", default=False)
 
-_console_formatter = (
-    "localdev" if env("CUSTOM_LOCAL_LOGGER_ENABLED", default=False) else "json"
-)
+_console_formatter = "localdev" if CUSTOM_LOCAL_LOGGER_ENABLED else "json"
 
 LOGGING: dict[str, Any] = {
     "version": 1,


### PR DESCRIPTION
This is a hotfix follow-up to [this](https://github.com/mozilla-services/consvc-shepherd/commit/2b9e0716265d85bf0ea9dc9d07d4791fdbb9cd28)

The error following error is occurring in staging when trying to run the boostr script: `django.core.exceptions.ImproperlyConfigured: Requested setting USE_I18N, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.`

I can't seem to recreate this locally, but it appears this is likely the right fix. Curious if folks who have better django knowledge can have some input here.