### PR TITLE
[SHEP-36] BUG FIX: accidently removed settings env variable setting path.

### DIFF
--- a/consvc_shepherd/settings.py
+++ b/consvc_shepherd/settings.py
@@ -175,10 +175,9 @@ STORAGES: dict[str, Any] = {
 
 GS_BUCKET_FILE_NAME = env("GS_BUCKET_FILE_NAME", default="settings_from_shepherd")
 ALLOCATION_FILE_NAME: str = env("ALLOCATION_FILE_NAME", default="allocation_file")
+CUSTOM_LOCAL_LOGGER_ENABLED: bool = env("CUSTOM_LOCAL_LOGGER_ENABLED", default=False)
 
-_console_formatter = (
-    "localdev" if env("CUSTOM_LOCAL_LOGGER_ENABLED", default=False) else "json"
-)
+_console_formatter = "localdev" if CUSTOM_LOCAL_LOGGER_ENABLED else "json"
 
 LOGGING: dict[str, Any] = {
     "version": 1,

--- a/manage.py
+++ b/manage.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
 import sys
+import os
+
 
 def main():
     """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "consvc_shepherd.settings")
 
     try:
         from django.core.management import execute_from_command_line


### PR DESCRIPTION
Found the issue for failing builds. Accidentally removed the deceleration of the os env that sets the global settings.py path for django. 